### PR TITLE
readme: add `hexb.in` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Allowing maximum enjoyment from receivers of stickers, and allow sticker compani
 This specification is also a definitive place to know what dimensions a sticker should be.
 
 The main spec is available at https://terinjokes.github.io/StickerConstructorSpec, generated from the `index.bs` file.
+
+## See also
+- [hexb.in - community curated list for hexagon logos](http://hexb.in/)


### PR DESCRIPTION
This adds a link to [hexb.in](http://hexb.in/), a community curated list for hexagon logos
