### PR TITLE
Add Triangle Sticker

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,10 @@ A <dfn>square sticker</dfn> must be represented by a square with sides of exactl
 A <dfn>hexagon sticker</dfn> must be represented by a regular hexagon with the largest diagonals measuring exactly 5.08 centimeters.
 The sticker must be oriented with a vertex positioned at the top.
 
+<h3 id="type-triangle">Triangle Sticker</h3>
+A <dfn>triangle sticker</dfn> must be represented by an equilateral triangle with sides of exactly 5.08 centimeters.
+The sticker must be oriented with a vertex positioned at the top.
+
 <h2 id="acks" class="no-num">Acknowledgements</h2>
 
 The editor would like to thank


### PR DESCRIPTION
Circle stickers were nixed in #1 due to inefficient space usage. Triangles, on the other hand, [tesselate just fine](http://en.wikipedia.org/wiki/Triangular_tiling).

2.54cm sides would allow some [cool interactions](http://en.wikipedia.org/wiki/Trihexagonal_tiling) with hexagon stickers, but I thought these might be far too small to be of any use. Went with 5.08cm.
