### PR TITLE
Issue #8: Adding hexagonal and square SVG templates for Inkscape

### DIFF
--- a/assets/hexagonal-sticker_template.svg
+++ b/assets/hexagonal-sticker_template.svg
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8.5in"
+   height="11in"
+   viewBox="0 0 765.00001 990.00003"
+   id="svg7307"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="hexagonal-sticker_template.svg">
+  <defs
+     id="defs7309" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.4121212"
+     inkscape:cx="316.35347"
+     inkscape:cy="824.77921"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer4"
+     showgrid="false"
+     units="in"
+     fit-margin-top="1"
+     fit-margin-bottom="1"
+     fit-margin-right="1"
+     fit-margin-left="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="526.50754,705.18846"
+       orientation="0,1"
+       id="guide8412" />
+    <sodipodi:guide
+       position="562.98996,525.67841"
+       orientation="0,1"
+       id="guide8414" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7312">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Template Text"
+     style="display:inline">
+    <text
+       sodipodi:linespacing="521%"
+       id="text8212"
+       y="101.80281"
+       x="42.59306"
+       style="font-style:normal;font-weight:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="101.80281"
+         x="42.59306"
+         id="tspan8214"
+         sodipodi:role="line">5.08 cm / 2&quot; Hexagonal Sticker Template</tspan></text>
+    <text
+       transform="translate(178.67433,582.63783)"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:29.74009705px;line-height:120.00000477%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-85.936043"
+       y="-454.19525"
+       id="text8216"
+       sodipodi:linespacing="120%"><tspan
+         id="tspan8220"
+         sodipodi:role="line"
+         x="-85.936043"
+         y="-454.19525"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start">(This template follows the StickerConstructorSpec at github.com/terinjokes/StickerconstructorSpec)</tspan></text>
+    <rect
+       transform="translate(178.67433,582.63783)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#0093d9;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000003, 4.00000005;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8406"
+       width="21.230001"
+       height="21.23"
+       x="38.762836"
+       y="25.453775" />
+    <rect
+       transform="translate(178.67433,582.63783)"
+       y="-18.546227"
+       x="38.762836"
+       height="21.23"
+       width="21.230001"
+       id="rect8408"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#db3279;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1" />
+    <rect
+       transform="translate(178.67433,582.63783)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8426"
+       width="21.230001"
+       height="21.23"
+       x="38.762836"
+       y="69.453773" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="255.83966"
+       y="580.09589"
+       id="text8536"
+       sodipodi:linespacing="521%"><tspan
+         sodipodi:role="line"
+         id="tspan8538"
+         x="255.83966"
+         y="580.09589"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Safe area <tspan
+   style="font-weight:normal"
+   id="tspan8540">- Keep all text inside this border</tspan></tspan></text>
+    <text
+       sodipodi:linespacing="521%"
+       id="text8542"
+       y="624.09589"
+       x="255.83966"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="624.09589"
+         x="255.83966"
+         id="tspan8544"
+         sodipodi:role="line">Trim <tspan
+   id="tspan8546"
+   style="font-weight:normal">- Outer edge of sticker</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="255.83966"
+       y="668.09589"
+       id="text8548"
+       sodipodi:linespacing="521%"><tspan
+         sodipodi:role="line"
+         id="tspan8550"
+         x="255.83966"
+         y="668.09589"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
+           style="font-weight:normal"
+           id="tspan8552"><tspan
+   style="font-weight:bold"
+   id="tspan8554">Bleed</tspan> - This area will be trimmed off</tspan></tspan></text>
+    <text
+       sodipodi:linespacing="521%"
+       id="text8556"
+       y="748.41248"
+       x="326.5592"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="748.41248"
+         x="326.5592"
+         id="tspan8558"
+         sodipodi:role="line">Make sure you:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:150%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="176.30603"
+       y="788.41248"
+       id="text8562"
+       sodipodi:linespacing="150%"><tspan
+         sodipodi:role="line"
+         id="tspan8564"
+         x="176.30603"
+         y="788.41248"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
+   style="font-weight:bold;line-height:150%"
+   id="tspan8572">1.</tspan> Put your artwork in the &quot;Artwork&quot; layer.</tspan><tspan
+         sodipodi:role="line"
+         x="176.30603"
+         y="810.36151"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="tspan8568"><tspan
+   style="font-weight:bold;line-height:150%"
+   id="tspan8574">2.</tspan> Outline your text. (Select text, then Paths &gt; Object to Path) </tspan></text>
+  </g>
+  <g
+     inkscape:label="Artwork"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(178.67433,582.63783)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:type="star"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#f0a028;stroke-width:25.03716469;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path17178"
+       sodipodi:sides="6"
+       sodipodi:cx="121.90476"
+       sodipodi:cy="126.57602"
+       sodipodi:r1="103.56153"
+       sodipodi:r2="103.56153"
+       sodipodi:arg1="-0.52327829"
+       sodipodi:arg2="0.0003204856"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 211.60827,74.824 -0.0332,103.56153 -89.70351,51.75202 -89.670315,-51.80951 0.03319,-103.561527 89.703505,-51.752019 z"
+       inkscape:transform-center-x="0.32645456"
+       inkscape:transform-center-y="-1.460707"
+       transform="matrix(0.80733155,0,0,0.81026646,105.40811,-310.19813)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Trim Lines"
+     style="display:inline">
+    <path
+       transform="matrix(0.86033594,0,0,0.86346354,277.62095,265.70622)"
+       inkscape:transform-center-y="-1.5566024"
+       inkscape:transform-center-x="0.34789098"
+       d="m 211.60827,74.824 -0.0332,103.56153 -89.70351,51.75202 -89.670315,-51.80951 0.03319,-103.561527 89.703505,-51.752019 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="true"
+       sodipodi:arg2="0.0003204856"
+       sodipodi:arg1="-0.52327829"
+       sodipodi:r2="103.56153"
+       sodipodi:r1="103.56153"
+       sodipodi:cy="126.57602"
+       sodipodi:cx="121.90476"
+       sodipodi:sides="6"
+       id="path7936"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0093d9;stroke-width:1.16022968;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.32045933, 4.64091866;stroke-dashoffset:7.51718092;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:type="star" />
+    <path
+       sodipodi:type="star"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#db3279;stroke-width:1.23811221;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:7.51718092;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path8410"
+       sodipodi:sides="6"
+       sodipodi:cx="121.90476"
+       sodipodi:cy="126.57602"
+       sodipodi:r1="103.56153"
+       sodipodi:r2="103.56153"
+       sodipodi:arg1="-0.52327829"
+       sodipodi:arg2="0.0003204856"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 211.60827,74.824 -0.0332,103.56153 -89.70351,51.75202 -89.670315,-51.80951 0.03319,-103.561527 89.703505,-51.752019 z"
+       inkscape:transform-center-x="0.32600218"
+       inkscape:transform-center-y="-1.4586807"
+       transform="matrix(0.80621714,0,0,0.809148,284.21829,272.58127)" />
+    <path
+       sodipodi:type="star"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.09156573;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:7.51718092;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path8424"
+       sodipodi:sides="6"
+       sodipodi:cx="121.90476"
+       sodipodi:cy="126.57602"
+       sodipodi:r1="103.56153"
+       sodipodi:r2="103.56153"
+       sodipodi:arg1="-0.52327829"
+       sodipodi:arg2="0.0003204856"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 211.60827,74.824 -0.0332,103.56153 -89.70351,51.75202 -89.670315,-51.80951 0.03319,-103.561527 89.703505,-51.752019 z"
+       inkscape:transform-center-x="0.3697741"
+       inkscape:transform-center-y="-1.6545161"
+       transform="matrix(0.91445474,0,0,0.91777907,271.02361,258.83118)" />
+    <g
+       id="g4595"
+       transform="matrix(1.2367579,0,0,-1.2367579,267.26742,1019.4899)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path470"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 210.14,593.273 -11.002,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path472"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 210.14,449.273 -11.002,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path474"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 204.639,449.273 0,144" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path476"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 204.639,455.424 3.549,0 -1.774,-3.076 -1.775,-3.075 -1.776,3.075 -1.773,3.076 3.549,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path478"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 204.639,587.124 -3.549,0 1.773,3.076 1.776,3.073 1.775,-3.073 1.774,-3.076 -3.549,0" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-400.8819"
+       y="516.31042"
+       id="text8536-9"
+       sodipodi:linespacing="521%"
+       transform="matrix(0,-1,1,0,0,0)"><tspan
+         sodipodi:role="line"
+         id="tspan8538-3"
+         x="-400.8819"
+         y="516.31042"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">5.08 cm</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Preview Without Bleeds"
+     sodipodi:insensitive="true"
+     style="display:inline">
+    <path
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:20.25;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       d="m 269.94336,252.9082 0,244.1836 225.11328,0 0,-244.1836 -225.11328,0 z m 112.58594,32.66992 77.14648,44.73633 -0.0293,89.42188 -77.17578,44.68555 -77.14648,-44.73633 0.0293,-89.42188 77.17578,-44.68555 z"
+       id="rect8416"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/assets/hexagonal-sticker_template.svg
+++ b/assets/hexagonal-sticker_template.svg
@@ -26,10 +26,10 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="2.4121212"
-     inkscape:cx="316.35347"
-     inkscape:cy="824.77921"
+     inkscape:cx="400.51176"
+     inkscape:cy="360.4576"
      inkscape:document-units="px"
-     inkscape:current-layer="layer4"
+     inkscape:current-layer="text8556"
      showgrid="false"
      units="in"
      fit-margin-top="1"
@@ -68,32 +68,642 @@
      inkscape:groupmode="layer"
      id="layer4"
      inkscape:label="Template Text"
-     style="display:inline">
-    <text
-       sodipodi:linespacing="521%"
-       id="text8212"
-       y="101.80281"
-       x="42.59306"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <g
        style="font-style:normal;font-weight:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+       id="text8212">
+      <path
+         d="m 52.787113,86.295895 q 3.519771,0 5.595108,1.975721 2.091939,1.97572 2.091939,5.412478 0,4.06766 -2.507007,6.259215 -2.507006,2.191551 -7.172363,2.191551 -4.051057,0 -6.541461,-1.31161 l 0,-4.432917 q 1.311613,0.697313 3.054895,1.145586 1.743283,0.43167 3.303936,0.43167 4.698562,0 4.698562,-3.851825 0,-3.669195 -4.864589,-3.669195 -0.879942,0 -1.942515,0.182629 -1.062572,0.166027 -1.72668,0.365259 l -2.042131,-1.095777 0.913148,-12.369007 13.165936,0 0,4.349906 -8.666606,0 -0.448273,4.764973 0.581094,-0.116219 q 1.012765,-0.232438 2.507007,-0.232438 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="101.80281"
-         x="42.59306"
-         id="tspan8214"
-         sodipodi:role="line">5.08 cm / 2&quot; Hexagonal Sticker Template</tspan></text>
-    <text
+         id="path5249"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 63.92752,99.428626 q 0,-1.394627 0.747121,-2.108542 0.747121,-0.713916 2.174953,-0.713916 1.378023,0 2.125144,0.730518 0.763724,0.730519 0.763724,2.09194 0,1.311614 -0.763724,2.075334 -0.763724,0.74712 -2.125144,0.74712 -1.394627,0 -2.158351,-0.73052 -0.763723,-0.74712 -0.763723,-2.091934 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5251"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 89.877529,89.666242 q 0,6.358831 -2.09194,9.413727 -2.075336,3.054891 -6.408639,3.054891 -4.200482,0 -6.342229,-3.154507 -2.125145,-3.154512 -2.125145,-9.314111 0,-6.425242 2.075337,-9.463535 2.075336,-3.054896 6.392037,-3.054896 4.200481,0 6.342228,3.187717 2.158351,3.187718 2.158351,9.330714 z m -11.870926,0 q 0,4.466124 0.763724,6.40864 0.780326,1.925912 2.606623,1.925912 1.793091,0 2.59002,-1.959118 0.796929,-1.959118 0.796929,-6.375434 0,-4.466124 -0.813532,-6.40864 -0.796929,-1.959117 -2.573417,-1.959117 -1.809694,0 -2.59002,1.959117 -0.780327,1.942516 -0.780327,6.40864 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5253"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 100.8021,77.214222 q 3.48657,0 5.61171,1.593859 2.14175,1.577256 2.14175,4.266892 0,1.859501 -1.02937,3.320538 -1.02937,1.444435 -3.32054,2.590021 2.72284,1.461037 3.90163,3.054895 1.1954,1.577256 1.1954,3.469963 0,2.988485 -2.34098,4.81478 -2.34098,1.80969 -6.1596,1.80969 -3.984646,0 -6.259215,-1.69347 -2.274569,-1.693475 -2.274569,-4.798178 0,-2.075337 1.095777,-3.685798 1.112381,-1.610462 3.552977,-2.839061 -2.075337,-1.311613 -2.988485,-2.805855 -0.913148,-1.494242 -0.913148,-3.270731 0,-2.606622 2.15835,-4.217084 2.15835,-1.610461 5.628313,-1.610461 z m -3.785414,18.130141 q 0,1.427832 0.996161,2.224761 0.996162,0.796929 2.722843,0.796929 1.90931,0 2.85566,-0.813532 0.94636,-0.830134 0.94636,-2.174953 0,-1.11238 -0.94636,-2.075336 -0.92975,-0.979559 -3.03829,-2.075337 -3.536374,1.627064 -3.536374,4.117468 z m 3.752204,-14.377932 q -1.311608,0 -2.12514,0.68071 -0.796929,0.664108 -0.796929,1.793091 0,0.996162 0.630902,1.793091 0.647505,0.780327 2.324377,1.610461 1.62706,-0.763724 2.27457,-1.560653 0.6475,-0.796929 0.6475,-1.842899 0,-1.145586 -0.83013,-1.809693 -0.83014,-0.664108 -2.12515,-0.664108 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5255"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 129.49155,102.13486 q -8.66661,0 -8.66661,-9.513339 0,-4.731767 2.35759,-7.222171 2.35758,-2.507007 6.75729,-2.507007 3.22093,0 5.77774,1.261805 l -1.49424,3.918235 q -1.1954,-0.481478 -2.22476,-0.780326 -1.02937,-0.315451 -2.05874,-0.315451 -3.95144,0 -3.95144,5.61171 0,5.445683 3.95144,5.445683 1.46104,0 2.70624,-0.381862 1.2452,-0.398464 2.49041,-1.228599 l 0,4.333302 q -1.2286,0.78033 -2.49041,1.07918 -1.2452,0.29884 -3.15451,0.29884 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5257"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 156.03926,101.80281 -5.06382,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10855,-1.012765 -1.94251,0 -2.82245,1.427832 -0.87995,1.427832 -0.87995,4.698562 l 0,8.733016 -5.06382,0 0,-18.56181 3.86843,0 0.68071,2.374185 0.28225,0 q 0.74712,-1.278407 2.15835,-1.992323 1.41122,-0.730519 3.23752,-0.730519 4.16728,0 5.64492,2.722842 l 0.44827,0 q 0.74712,-1.29501 2.19155,-2.008926 1.46104,-0.713916 3.28734,-0.713916 3.15451,0 4.76497,1.627064 1.62706,1.610461 1.62706,5.18004 l 0,12.103363 -5.08042,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10854,-1.012765 -1.8595,0 -2.78925,1.328216 -0.91315,1.328215 -0.91315,4.217084 l 0,9.31411 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5259"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 192.88064,77.529673 -9.04847,24.273137 -4.59894,0 9.04847,-24.273137 4.59894,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5261"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.24188,101.80281 -16.96796,0 0,-3.569578 6.09319,-6.1596 q 2.70624,-2.772649 3.53638,-3.835222 0.83013,-1.079175 1.19539,-1.992323 0.36526,-0.913148 0.36526,-1.892707 0,-1.461037 -0.81353,-2.174953 -0.79693,-0.713915 -2.14175,-0.713915 -1.41123,0 -2.73945,0.647505 -1.32821,0.647505 -2.77265,1.842899 l -2.78925,-3.303936 q 1.79309,-1.527448 2.97188,-2.15835 1.1788,-0.630903 2.57342,-0.962957 1.39463,-0.348656 3.12131,-0.348656 2.27457,0 4.01785,0.830134 1.74328,0.830135 2.70624,2.324377 0.96296,1.494243 0.96296,3.420155 0,1.676872 -0.5977,3.154512 -0.5811,1.461037 -1.8263,3.005087 -1.2286,1.544051 -4.3499,4.399714 l -3.12131,2.938677 0,0.232437 10.57592,0 0,4.3167 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5263"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 228.14475,77.529673 -0.68071,8.766222 -3.27073,0 -0.68071,-8.766222 4.63215,0 z m 7.00634,0 -0.68071,8.766222 -3.27074,0 -0.68071,-8.766222 4.63216,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5265"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 269.15341,101.80281 -5.13023,0 0,-10.476299 -9.61296,0 0,10.476299 -5.14683,0 0,-24.273137 5.14683,0 0,9.513343 9.61296,0 0,-9.513343 5.13023,0 0,24.273137 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5267"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 282.58499,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55681,-1.029367 z m 0.71392,15.639732 q -4.48273,0 -7.00634,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32438,-7.205569 2.34098,-2.556815 6.45844,-2.556815 3.93484,0 6.1264,2.241364 2.19155,2.241363 2.19155,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67688,0 3.17112,-0.348656 1.49424,-0.348657 3.1213,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51084,0.33205 -3.68579,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5269"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 298.82241,92.322673 -5.97697,-9.081673 5.74453,0 3.60279,5.910559 3.63599,-5.910559 5.74453,0 -6.04338,9.081673 6.32563,9.480137 -5.76114,0 -3.90163,-6.358831 -3.91824,6.358831 -5.74453,0 6.29242,-9.480137 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5271"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 326.4659,101.80281 -0.97956,-2.523609 -0.13282,0 q -1.27841,1.610459 -2.63983,2.241359 -1.34482,0.6143 -3.51977,0.6143 -2.67303,0 -4.21708,-1.52744 -1.52745,-1.527451 -1.52745,-4.349909 0,-2.955279 2.05873,-4.349905 2.07534,-1.411229 6.24262,-1.560654 l 3.22092,-0.09962 0,-0.813532 q 0,-2.822458 -2.88887,-2.822458 -2.22476,0 -5.22985,1.344819 l -1.67687,-3.420155 q 3.20432,-1.676872 7.10595,-1.676872 3.73561,0 5.72793,1.627064 1.99232,1.627064 1.99232,4.947602 l 0,12.36901 -3.53637,0 z m -1.49424,-8.600194 -1.95912,0.06641 q -2.20816,0.06641 -3.28733,0.79693 -1.07918,0.730518 -1.07918,2.224761 0,2.141747 2.4572,2.141747 1.75989,0 2.80586,-1.012764 1.06257,-1.012765 1.06257,-2.689637 l 0,-1.527447 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5273"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 351.35334,83.241 0,2.573417 -2.90547,0.747121 q 0.79693,1.245202 0.79693,2.789253 0,2.988485 -2.09194,4.665357 -2.07533,1.660269 -5.77774,1.660269 l -0.91314,-0.04981 -0.74712,-0.08301 q -0.78033,0.597697 -0.78033,1.328216 0,1.095778 2.78925,1.095778 l 3.15451,0 q 3.0549,0 4.64876,1.311612 1.61046,1.311607 1.61046,3.851827 0,3.25412 -2.72284,5.04721 -2.70624,1.7931 -7.78667,1.7931 -3.88503,0 -5.94376,-1.36143 -2.04213,-1.34481 -2.04213,-3.78541 0,-1.67687 1.04597,-2.80585 1.04597,-1.12899 3.0715,-1.61047 -0.78033,-0.33205 -1.36142,-1.079169 -0.5811,-0.763723 -0.5811,-1.610461 0,-1.062572 0.6143,-1.759885 0.6143,-0.713916 1.77649,-1.394627 -1.46104,-0.630902 -2.32438,-2.025528 -0.84674,-1.394626 -0.84674,-3.287333 0,-3.038293 1.97572,-4.698562 1.97573,-1.66027 5.64492,-1.66027 0.78033,0 1.8429,0.149424 1.07917,0.132822 1.37802,0.199233 l 6.47505,0 z m -14.32812,21.18504 q 0,1.04597 0.99616,1.64366 1.01276,0.5977 2.82246,0.5977 2.72284,0 4.26689,-0.74712 1.54405,-0.74712 1.54405,-2.04213 0,-1.04597 -0.91315,-1.44444 -0.91315,-0.39846 -2.82245,-0.39846 l -2.62323,0 q -1.39463,0 -2.34098,0.6475 -0.92975,0.66411 -0.92975,1.74329 z m 1.8429,-15.108455 q 0,1.510846 0.68071,2.390788 0.69731,0.879943 2.10854,0.879943 1.42783,0 2.09194,-0.879943 0.66411,-0.879942 0.66411,-2.390788 0,-3.353744 -2.75605,-3.353744 -2.78925,0 -2.78925,3.353744 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5275"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 358.4261,92.4887 q 0,2.756047 0.89654,4.167276 0.91315,1.411229 2.95528,1.411229 2.02553,0 2.90547,-1.394627 0.89655,-1.411228 0.89655,-4.183878 0,-2.756047 -0.89655,-4.134071 -0.89654,-1.378023 -2.93867,-1.378023 -2.02553,0 -2.92208,1.378023 -0.89654,1.361421 -0.89654,4.134071 z m 12.83388,0 q 0,4.532535 -2.39079,7.08935 -2.39079,2.55681 -6.65768,2.55681 -2.67303,0 -4.71517,-1.16218 -2.04213,-1.178795 -3.1379,-3.370351 -1.09578,-2.191555 -1.09578,-5.113629 0,-4.549138 2.37418,-7.072747 2.37419,-2.52361 6.67429,-2.52361 2.67303,0 4.71516,1.162189 2.04213,1.162188 3.13791,3.337141 1.09578,2.174953 1.09578,5.097027 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5277"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 392.57784,101.80281 -5.06383,0 0,-10.841558 q 0,-2.008926 -0.71391,-3.005087 -0.71392,-1.012765 -2.27457,-1.012765 -2.12514,0 -3.0715,1.427832 -0.94635,1.411229 -0.94635,4.698562 l 0,8.733016 -5.06382,0 0,-18.56181 3.86842,0 0.68071,2.374185 0.28225,0 q 0.84674,-1.344818 2.32438,-2.025529 1.49424,-0.697313 3.38695,-0.697313 3.23752,0 4.91439,1.759886 1.67688,1.743282 1.67688,5.047218 l 0,12.103363 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5279"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 409.6122,101.80281 -0.97956,-2.523609 -0.13282,0 q -1.27841,1.610459 -2.63983,2.241359 -1.34482,0.6143 -3.51977,0.6143 -2.67303,0 -4.21708,-1.52744 -1.52745,-1.527451 -1.52745,-4.349909 0,-2.955279 2.05873,-4.349905 2.07534,-1.411229 6.24262,-1.560654 l 3.22092,-0.09962 0,-0.813532 q 0,-2.822458 -2.88887,-2.822458 -2.22476,0 -5.22985,1.344819 l -1.67687,-3.420155 q 3.20432,-1.676872 7.10595,-1.676872 3.73561,0 5.72793,1.627064 1.99232,1.627064 1.99232,4.947602 l 0,12.36901 -3.53637,0 z m -1.49424,-8.600194 -1.95912,0.06641 q -2.20816,0.06641 -3.28733,0.79693 -1.07918,0.730518 -1.07918,2.224761 0,2.141747 2.4572,2.141747 1.75989,0 2.80586,-1.012764 1.06257,-1.012765 1.06257,-2.689637 l 0,-1.527447 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5281"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 423.40901,101.80281 -5.06382,0 0,-25.83379 5.06382,0 0,25.83379 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5283"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 452.2645,95.062117 q 0,3.287333 -2.37418,5.180043 -2.35759,1.8927 -6.57467,1.8927 -3.88503,0 -6.87352,-1.46103 l 0,-4.781578 q 2.4572,1.095778 4.15068,1.54405 1.71007,0.448273 3.1213,0.448273 1.69348,0 2.59002,-0.647505 0.91315,-0.647505 0.91315,-1.925912 0,-0.713916 -0.39846,-1.261805 -0.39847,-0.564492 -1.17879,-1.079175 -0.76373,-0.514684 -3.13791,-1.643667 -2.22476,-1.045969 -3.33714,-2.008926 -1.11238,-0.962956 -1.77649,-2.241363 -0.66411,-1.278408 -0.66411,-2.988485 0,-3.220922 2.17495,-5.063821 2.19156,-1.842899 6.04338,-1.842899 1.89271,0 3.60279,0.448272 1.72668,0.448273 3.60278,1.261805 l -1.66027,4.001249 q -1.94251,-0.796929 -3.22092,-1.11238 -1.2618,-0.315451 -2.4904,-0.315451 -1.46104,0 -2.24137,0.68071 -0.78032,0.68071 -0.78032,1.776488 0,0.680711 0.31545,1.195394 0.31545,0.498081 0.99616,0.979559 0.69731,0.464875 3.27073,1.693475 3.40355,1.627064 4.66536,3.27073 1.2618,1.627064 1.2618,4.001249 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5285"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 464.08562,98.10041 q 1.32822,0 3.18772,-0.581094 l 0,3.768814 q -1.89271,0.84673 -4.64875,0.84673 -3.0383,0 -4.43292,-1.52744 -1.37802,-1.544054 -1.37802,-4.615552 l 0,-8.948852 -2.424,0 0,-2.141747 2.78925,-1.693475 1.46104,-3.918235 3.23753,0 0,3.951441 5.19664,0 0,3.802016 -5.19664,0 0,8.948852 q 0,1.079175 0.59769,1.593859 0.6143,0.514683 1.61046,0.514683 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5287"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 470.79312,78.442821 q 0,-2.473801 2.75604,-2.473801 2.75605,0 2.75605,2.473801 0,1.178792 -0.69731,1.842899 -0.68071,0.647505 -2.05874,0.647505 -2.75604,0 -2.75604,-2.490404 z m 5.27965,23.359989 -5.06382,0 0,-18.56181 5.06382,0 0,18.56181 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5289"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 488.90665,102.13486 q -8.66661,0 -8.66661,-9.513339 0,-4.731767 2.35759,-7.222171 2.35758,-2.507007 6.75729,-2.507007 3.22093,0 5.77774,1.261805 l -1.49424,3.918235 q -1.1954,-0.481478 -2.22476,-0.780326 -1.02937,-0.315451 -2.05874,-0.315451 -3.95144,0 -3.95144,5.61171 0,5.445683 3.95144,5.445683 1.46104,0 2.70624,-0.381862 1.2452,-0.398464 2.49041,-1.228599 l 0,4.333302 q -1.2286,0.78033 -2.49041,1.07918 -1.2452,0.29884 -3.15451,0.29884 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5291"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 503.69965,91.708373 2.20816,-2.822458 5.19664,-5.644915 5.71133,0 -7.3716,8.052306 7.81987,10.509504 -5.84415,0 -5.34606,-7.521019 -2.17496,1.743282 0,5.777737 -5.06382,0 0,-25.83379 5.06382,0 0,11.522269 -0.26564,4.217084 0.0664,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5293"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 527.64073,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97955,-2.888868 -0.94636,-1.029367 -2.55682,-1.029367 z m 0.71392,15.639732 q -4.48273,0 -7.00634,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32438,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93483,0 6.12639,2.241364 2.19155,2.241363 2.19155,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67688,0 3.17112,-0.348656 1.49424,-0.348657 3.1213,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51084,0.33205 -3.68579,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5295"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 550.43623,82.892343 q 1.02937,0 1.71008,0.149424 l -0.38186,4.748371 q -0.6143,-0.166027 -1.49425,-0.166027 -2.42399,0 -3.78541,1.245202 -1.34482,1.245202 -1.34482,3.486565 l 0,9.446932 -5.06382,0 0,-18.56181 3.83522,0 0.74712,3.121306 0.24904,0 q 0.86334,-1.560653 2.32438,-2.507007 1.47764,-0.962956 3.20432,-0.962956 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5297"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 574.14487,101.80281 -5.14684,0 0,-19.989642 -6.59126,0 0,-4.283495 18.32937,0 0,4.283495 -6.59127,0 0,19.989642 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5299"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 591.79353,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10596,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94636,-1.029367 -2.55682,-1.029367 z m 0.71392,15.639732 q -4.48273,0 -7.00634,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32438,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93483,0 6.12639,2.241364 2.19156,2.241363 2.19156,6.192804 l 0,2.457199 -11.97055,0 q 0.083,2.15835 1.27841,3.370347 1.1954,1.211996 3.35375,1.211996 1.67687,0 3.17111,-0.348656 1.49424,-0.348657 3.12131,-1.112381 l 0,3.918234 q -1.32822,0.66411 -2.83906,0.97956 -1.51085,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5301"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 620.84828,101.80281 -5.06382,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10855,-1.012765 -1.94251,0 -2.82245,1.427832 -0.87995,1.427832 -0.87995,4.698562 l 0,8.733016 -5.06382,0 0,-18.56181 3.86843,0 0.68071,2.374185 0.28225,0 q 0.74712,-1.278407 2.15835,-1.992323 1.41123,-0.730519 3.23752,-0.730519 4.16728,0 5.64492,2.722842 l 0.44827,0 q 0.74712,-1.29501 2.19156,-2.008926 1.46103,-0.713916 3.28733,-0.713916 3.15451,0 4.76497,1.627064 1.62707,1.610461 1.62707,5.18004 l 0,12.103363 -5.08043,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10854,-1.012765 -1.8595,0 -2.78925,1.328216 -0.91315,1.328215 -0.91315,4.217084 l 0,9.31411 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5303"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 647.82764,102.13486 q -3.27073,0 -5.13023,-2.374181 l -0.26565,0 q 0.26565,2.324381 0.26565,2.689641 l 0,7.52102 -5.06383,0 0,-26.73034 4.11747,0 0.71392,2.40739 0.23244,0 q 1.77648,-2.756047 5.26305,-2.756047 3.28733,0 5.14683,2.540212 1.85951,2.540212 1.85951,7.056145 0,2.971882 -0.87995,5.163437 -0.86334,2.191556 -2.4738,3.337143 -1.61046,1.14558 -3.78541,1.14558 z M 646.3334,86.9434 q -1.87611,0 -2.73945,1.162189 -0.86334,1.145586 -0.89654,3.802017 l 0,0.547888 q 0,2.988485 0.87994,4.283495 0.89654,1.29501 2.82246,1.29501 3.40355,0 3.40355,-5.61171 0,-2.739444 -0.84674,-4.100865 Q 648.12649,86.9434 646.3334,86.9434 Z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5305"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 664.2145,101.80281 -5.06383,0 0,-25.83379 5.06383,0 0,25.83379 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5307"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 681.29863,101.80281 -0.97956,-2.523609 -0.13282,0 q -1.2784,1.610459 -2.63983,2.241359 -1.34481,0.6143 -3.51977,0.6143 -2.67303,0 -4.21708,-1.52744 -1.52745,-1.527451 -1.52745,-4.349909 0,-2.955279 2.05874,-4.349905 2.07533,-1.411229 6.24261,-1.560654 l 3.22092,-0.09962 0,-0.813532 q 0,-2.822458 -2.88887,-2.822458 -2.22476,0 -5.22985,1.344819 L 670.0088,84.53601 q 3.20432,-1.676872 7.10595,-1.676872 3.73561,0 5.72793,1.627064 1.99233,1.627064 1.99233,4.947602 l 0,12.369006 -3.53638,0 z m -1.49424,-8.600194 -1.95912,0.06641 q -2.20816,0.06641 -3.28733,0.79693 -1.07918,0.730518 -1.07918,2.224761 0,2.141747 2.4572,2.141747 1.75989,0 2.80586,-1.012764 1.06257,-1.012765 1.06257,-2.689637 l 0,-1.527447 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5309"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 697.85152,98.10041 q 1.32822,0 3.18772,-0.581094 l 0,3.768814 q -1.89271,0.84673 -4.64875,0.84673 -3.0383,0 -4.43292,-1.52744 -1.37803,-1.544054 -1.37803,-4.615552 l 0,-8.948852 -2.42399,0 0,-2.141747 2.78925,-1.693475 1.46104,-3.918235 3.23753,0 0,3.951441 5.19664,0 0,3.802016 -5.19664,0 0,8.948852 q 0,1.079175 0.59769,1.593859 0.6143,0.514683 1.61046,0.514683 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5311"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 712.46193,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55681,-1.029367 z m 0.71391,15.639732 q -4.48272,0 -7.00633,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32437,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93484,0 6.1264,2.241364 2.19155,2.241363 2.19155,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67687,0 3.17112,-0.348656 1.49424,-0.348657 3.1213,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51084,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5313"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
        transform="translate(178.67433,582.63783)"
-       xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:29.74009705px;line-height:120.00000477%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="-85.936043"
-       y="-454.19525"
-       id="text8216"
-       sodipodi:linespacing="120%"><tspan
-         id="tspan8220"
-         sodipodi:role="line"
-         x="-85.936043"
-         y="-454.19525"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start">(This template follows the StickerConstructorSpec at github.com/terinjokes/StickerconstructorSpec)</tspan></text>
+       id="text8216">
+      <path
+         d="m -85.433484,-457.63349 q 0,-1.62412 0.471914,-3.03986 0.478044,-1.41575 1.372843,-2.48215 l 0.992859,0 q -0.882541,1.18285 -1.329941,2.59859 -0.441271,1.41575 -0.441271,2.91117 0,1.4709 0.453528,2.87438 0.453529,1.40349 1.305427,2.56183 l -0.980602,0 q -0.900928,-1.04189 -1.372843,-2.43312 -0.471914,-1.39123 -0.471914,-2.99084 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5064"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -78.219932,-454.19525 -1.04189,0 0,-8.03481 -2.837616,0 0,-0.92544 6.717122,0 0,0.92544 -2.837616,0 0,8.03481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5066"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -69.596764,-454.19525 0,-4.34529 q 0,-0.82126 -0.373855,-1.22576 -0.373854,-0.40449 -1.170593,-0.40449 -1.060276,0 -1.550577,0.5761 -0.484172,0.5761 -0.484172,1.88766 l 0,3.51178 -1.017374,0 0,-9.53635 1.017374,0 0,2.88664 q 0,0.52095 -0.04903,0.86416 l 0.06129,0 q 0.30031,-0.48417 0.851898,-0.75997 0.557718,-0.28192 1.268654,-0.28192 1.231881,0 1.844757,0.58836 0.619005,0.58223 0.619005,1.85701 l 0,4.38207 -1.017374,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5068"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -65.478238,-454.19525 -1.017374,0 0,-6.71712 1.017374,0 0,6.71712 z m -1.103177,-8.53737 q 0,-0.34934 0.171606,-0.50868 0.171605,-0.16548 0.429013,-0.16548 0.24515,0 0.422884,0.16548 0.177735,0.16547 0.177735,0.50868 0,0.34321 -0.177735,0.51482 -0.177734,0.16548 -0.422884,0.16548 -0.257408,0 -0.429013,-0.16548 -0.171606,-0.17161 -0.171606,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5070"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -58.975621,-456.02775 q 0,0.9377 -0.698679,1.44639 -0.698679,0.50868 -1.961204,0.50868 -1.33607,0 -2.083779,-0.42288 l 0,-0.94383 q 0.484172,0.24515 1.035761,0.38611 0.557717,0.14096 1.072533,0.14096 0.796739,0 1.225753,-0.25128 0.429013,-0.2574 0.429013,-0.77835 0,-0.39224 -0.343211,-0.66803 -0.337082,-0.28193 -1.323812,-0.66191 -0.937701,-0.34934 -1.33607,-0.60675 -0.392241,-0.26353 -0.588361,-0.59449 -0.189992,-0.33095 -0.189992,-0.79061 0,-0.82125 0.668035,-1.29317 0.668035,-0.47804 1.8325,-0.47804 1.084791,0 2.120551,0.44127 l -0.361597,0.82738 q -1.011245,-0.41675 -1.832499,-0.41675 -0.723194,0 -1.09092,0.22676 -0.367726,0.22677 -0.367726,0.62514 0,0.26966 0.134833,0.45965 0.140962,0.19 0.4474,0.3616 0.306438,0.17161 1.176722,0.49643 1.195108,0.43514 1.611864,0.87641 0.422885,0.44127 0.422885,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5072"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -51.896902,-454.91232 q 0.269666,0 0.520945,-0.0368 0.251279,-0.0429 0.398369,-0.0858 l 0,0.77835 q -0.165476,0.0797 -0.490301,0.1287 -0.318695,0.0552 -0.576103,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962216,0 0,-0.4903 0.962216,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948946,0 0,0.79061 -1.948946,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5074"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -46.791642,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151196,-0.95609 1.262525,0 1.997976,0.83351 0.735451,0.82739 0.735451,2.18797 l 0,0.64352 -4.627215,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145067,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.023504,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808996,0 -1.293168,0.52707 -0.478044,0.52708 -0.563846,1.45865 l 3.51178,0 q 0,-0.96222 -0.429013,-1.47091 -0.429014,-0.51481 -1.225753,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5076"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -34.031562,-454.19525 0,-4.36981 q 0,-0.80287 -0.343211,-1.20124 -0.34321,-0.40449 -1.066404,-0.40449 -0.949958,0 -1.403487,0.54546 -0.453528,0.54546 -0.453528,1.67928 l 0,3.7508 -1.017374,0 0,-4.36981 q 0,-0.80287 -0.343211,-1.20124 -0.343211,-0.40449 -1.072533,-0.40449 -0.956087,0 -1.403487,0.5761 -0.44127,0.56997 -0.44127,1.8754 l 0,3.52404 -1.017375,0 0,-6.71712 0.827383,0 0.165476,0.91931 0.04903,0 q 0.288051,-0.4903 0.808996,-0.76609 0.527074,-0.2758 1.176722,-0.2758 1.575092,0 2.059264,1.13995 l 0.04903,0 q 0.30031,-0.52707 0.870284,-0.83351 0.569975,-0.30644 1.299298,-0.30644 1.139949,0 1.703795,0.58836 0.569975,0.58223 0.569975,1.86927 l 0,4.38207 -1.017374,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5078"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -27.798611,-454.07268 q -0.655777,0 -1.201237,-0.23902 -0.539331,-0.24515 -0.907057,-0.74771 l -0.07355,0 q 0.07355,0.58836 0.07355,1.11544 l 0,2.76407 -1.017374,0 0,-9.73247 0.827383,0 0.140961,0.91931 0.04903,0 q 0.392241,-0.55159 0.913186,-0.79674 0.520944,-0.24515 1.195108,-0.24515 1.33607,0 2.059264,0.91319 0.729323,0.91318 0.729323,2.56182 0,1.65476 -0.74158,2.57408 -0.735452,0.91318 -2.047007,0.91318 z m -0.14709,-6.09811 q -1.029632,0 -1.489289,0.56997 -0.459657,0.56998 -0.471915,1.81411 l 0,0.22677 q 0,1.41574 0.471915,2.02862 0.471915,0.60675 1.513804,0.60675 0.870284,0 1.360585,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.490301,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5080"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -22.209181,-454.19525 -1.017375,0 0,-9.53635 1.017375,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5082"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -15.908816,-454.19525 -0.202249,-0.95609 -0.04903,0 q -0.502559,0.63126 -1.005117,0.85803 -0.49643,0.22063 -1.244139,0.22063 -0.998988,0 -1.568963,-0.51481 -0.563846,-0.51482 -0.563846,-1.46478 0,-2.03474 3.254373,-2.13281 l 1.139949,-0.0368 0,-0.41675 q 0,-0.79061 -0.34321,-1.16447 -0.337082,-0.37998 -1.084791,-0.37998 -0.83964,0 -1.899916,0.51481 l -0.312567,-0.77835 q 0.49643,-0.26966 1.084791,-0.42288 0.59449,-0.15322 1.188979,-0.15322 1.201238,0 1.777341,0.5332 0.582233,0.5332 0.582233,1.70992 l 0,4.58432 -0.753838,0 z m -2.298286,-0.71707 q 0.949958,0 1.489289,-0.52094 0.54546,-0.52095 0.54546,-1.45865 l 0,-0.60674 -1.017374,0.0429 q -1.213495,0.0429 -1.752826,0.37998 -0.533202,0.33095 -0.533202,1.03576 0,0.55159 0.330953,0.83964 0.337082,0.28805 0.9377,0.28805 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5084"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -10.883226,-454.91232 q 0.269665,0 0.520945,-0.0368 0.251279,-0.0429 0.3983691,-0.0858 l 0,0.77835 q -0.1654761,0.0797 -0.4903011,0.1287 -0.318695,0.0552 -0.576103,0.0552 -1.948947,0 -1.948947,-2.05313 l 0,-3.99595 -0.962215,0 0,-0.4903 0.962215,-0.42289 0.429014,-1.43413 0.588361,0 0,1.55671 1.948946,0 0,0.79061 -1.948946,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288051,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5086"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -5.7779734,-454.07268 q -1.4892891,0 -2.3534444,-0.90705 -0.8580266,-0.90706 -0.8580266,-2.51892 0,-1.62413 0.7967389,-2.58021 0.8028678,-0.95609 2.1511953,-0.95609 1.2625249,0 1.9979762,0.83351 0.7354514,0.82739 0.7354514,2.18797 l 0,0.64352 -4.6272149,0 q 0.030644,1.18285 0.5944899,1.79573 0.5699748,0.61287 1.5996067,0.61287 1.0847908,0 2.1450665,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.0235031,0.33095 -0.4780434,0.10419 -1.1583359,0.10419 z m -0.2757943,-6.11037 q -0.8089965,0 -1.2931687,0.52707 -0.4780434,0.52708 -0.563846,1.45865 l 3.5117803,0 q 0,-0.96222 -0.4290133,-1.47091 -0.4290133,-0.51481 -1.2257523,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5088"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 4.7083362,-460.12176 -1.7099244,0 0,5.92651 -1.0173744,0 0,-5.92651 -1.20123728,0 0,-0.45966 1.20123728,-0.36773 0,-0.37385 q 0,-2.47602 2.1634528,-2.47602 0.5332022,0 1.2502673,0.21451 l -0.2635367,0.81512 q -0.5883611,-0.18999 -1.0051169,-0.18999 -0.5761036,0 -0.8518979,0.38611 -0.2757942,0.37998 -0.2757942,1.22575 l 0,0.43515 1.7099244,0 0,0.79061 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5090"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 11.744154,-457.55994 q 0,1.64251 -0.827383,2.56795 -0.827383,0.91931 -2.2860281,0.91931 -0.9009279,0 -1.5996067,-0.42288 -0.6986788,-0.42289 -1.078662,-1.2135 -0.3799832,-0.79061 -0.3799832,-1.85088 0,-1.64251 0.821254,-2.5557 0.821254,-0.91931 2.2798993,-0.91931 1.4096147,0 2.2369977,0.9377 0.833512,0.9377 0.833512,2.53731 z m -5.1175161,0 q 0,1.28704 0.514816,1.9612 0.514816,0.67417 1.5138041,0.67417 0.9989881,0 1.513804,-0.66804 0.520945,-0.67416 0.520945,-1.96733 0,-1.28091 -0.520945,-1.94282 -0.5148159,-0.66803 -1.5260615,-0.66803 -0.9989882,0 -1.5076754,0.65577 -0.5086872,0.65578 -0.5086872,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5092"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.538869,-454.19525 -1.017374,0 0,-9.53635 1.017374,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5094"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 17.725828,-454.19525 -1.017375,0 0,-9.53635 1.017375,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5096"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.69322,-457.55994 q 0,1.64251 -0.827383,2.56795 -0.827383,0.91931 -2.286028,0.91931 -0.900928,0 -1.599607,-0.42288 -0.698678,-0.42289 -1.078662,-1.2135 -0.379983,-0.79061 -0.379983,-1.85088 0,-1.64251 0.821254,-2.5557 0.821254,-0.91931 2.279899,-0.91931 1.409616,0 2.236998,0.9377 0.833512,0.9377 0.833512,2.53731 z m -5.117516,0 q 0,1.28704 0.514816,1.9612 0.514816,0.67417 1.513804,0.67417 0.998988,0 1.513804,-0.66804 0.520945,-0.67416 0.520945,-1.96733 0,-1.28091 -0.520945,-1.94282 -0.514816,-0.66803 -1.526061,-0.66803 -0.998988,0 -1.507676,0.65577 -0.508687,0.65578 -0.508687,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5098"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 32.955803,-454.19525 -1.231881,-3.9408 q -0.116447,-0.36159 -0.435142,-1.6425 l -0.04903,0 q -0.24515,1.07253 -0.429013,1.65476 l -1.268654,3.92854 -1.176722,0 -1.832499,-6.71712 1.066404,0 q 0.649649,2.53117 0.986731,3.85499 0.34321,1.32381 0.39224,1.78347 l 0.04903,0 q 0.06742,-0.34934 0.214506,-0.90093 0.153219,-0.55772 0.263537,-0.88254 l 1.231881,-3.85499 1.103177,0 1.201237,3.85499 q 0.343211,1.05414 0.465786,1.77121 l 0.04903,0 q 0.02452,-0.22064 0.128704,-0.68029 0.110318,-0.45966 1.280911,-4.94591 l 1.054147,0 -1.857014,6.71712 -1.207366,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5100"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 41.560584,-456.02775 q 0,0.9377 -0.698679,1.44639 -0.698679,0.50868 -1.961203,0.50868 -1.33607,0 -2.083779,-0.42288 l 0,-0.94383 q 0.484172,0.24515 1.03576,0.38611 0.557718,0.14096 1.072534,0.14096 0.796739,0 1.225752,-0.25128 0.429013,-0.2574 0.429013,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.337082,-0.28193 -1.323813,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.392241,-0.26353 -0.588361,-0.59449 -0.189992,-0.33095 -0.189992,-0.79061 0,-0.82125 0.668035,-1.29317 0.668035,-0.47804 1.8325,-0.47804 1.084791,0 2.120551,0.44127 l -0.361596,0.82738 q -1.011246,-0.41675 -1.8325,-0.41675 -0.723194,0 -1.09092,0.22676 -0.367725,0.22677 -0.367725,0.62514 0,0.26966 0.134832,0.45965 0.140962,0.19 0.4474,0.3616 0.306438,0.17161 1.176722,0.49643 1.195109,0.43514 1.611864,0.87641 0.422885,0.44127 0.422885,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.639303,-454.91232 q 0.269666,0 0.520945,-0.0368 0.251279,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.165477,0.0797 -0.490301,0.1287 -0.318696,0.0552 -0.576104,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962216,0 0,-0.4903 0.962216,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948947,0 0,0.79061 -1.948947,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5104"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 55.503518,-454.19525 0,-4.34529 q 0,-0.82126 -0.373854,-1.22576 -0.373855,-0.40449 -1.170594,-0.40449 -1.060275,0 -1.550576,0.5761 -0.484172,0.5761 -0.484172,1.88766 l 0,3.51178 -1.017375,0 0,-9.53635 1.017375,0 0,2.88664 q 0,0.52095 -0.04903,0.86416 l 0.06129,0 q 0.300309,-0.48417 0.851898,-0.75997 0.557717,-0.28192 1.268654,-0.28192 1.231881,0 1.844757,0.58836 0.619005,0.58223 0.619005,1.85701 l 0,4.38207 -1.017375,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5106"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 61.442287,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151195,-0.95609 1.262525,0 1.997977,0.83351 0.735451,0.82739 0.735451,2.18797 l 0,0.64352 -4.627215,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145066,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.023503,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808997,0 -1.293169,0.52707 -0.478043,0.52708 -0.563846,1.45865 l 3.511781,0 q 0,-0.96222 -0.429014,-1.47091 -0.429013,-0.51481 -1.225752,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5108"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 74.110428,-456.57934 q 0,1.18285 -0.858026,1.84476 -0.858027,0.6619 -2.32893,0.6619 -1.593478,0 -2.451504,-0.41062 l 0,-1.00512 q 0.551588,0.23289 1.201237,0.36773 0.649649,0.13483 1.28704,0.13483 1.041889,0 1.568963,-0.39224 0.527073,-0.39837 0.527073,-1.10318 0,-0.46579 -0.189991,-0.75997 -0.183863,-0.30031 -0.625134,-0.55158 -0.435142,-0.25128 -1.329941,-0.56998 -1.250268,-0.4474 -1.789599,-1.06027 -0.533202,-0.61288 -0.533202,-1.59961 0,-1.03576 0.778353,-1.64864 0.778353,-0.61287 2.059264,-0.61287 1.33607,0 2.457633,0.4903 l -0.324824,0.90705 q -1.109306,-0.46578 -2.157324,-0.46578 -0.827383,0 -1.293169,0.35547 -0.465786,0.35546 -0.465786,0.98673 0,0.46578 0.171606,0.76609 0.171605,0.29418 0.576103,0.54546 0.410627,0.24515 1.250267,0.54546 1.409616,0.50256 1.936689,1.07866 0.533202,0.57611 0.533202,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5110"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 77.959296,-454.91232 q 0.269665,0 0.520944,-0.0368 0.251279,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.165477,0.0797 -0.490301,0.1287 -0.318696,0.0552 -0.576104,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962215,0 0,-0.4903 0.962215,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948947,0 0,0.79061 -1.948947,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.790611,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5112"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 81.244314,-454.19525 -1.017375,0 0,-6.71712 1.017375,0 0,6.71712 z m -1.103177,-8.53737 q 0,-0.34934 0.171605,-0.50868 0.171605,-0.16548 0.429013,-0.16548 0.245151,0 0.422885,0.16548 0.177734,0.16547 0.177734,0.50868 0,0.34321 -0.177734,0.51482 -0.177734,0.16548 -0.422885,0.16548 -0.257408,0 -0.429013,-0.16548 -0.171605,-0.17161 -0.171605,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5114"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.098287,-454.07268 q -1.458645,0 -2.261512,-0.8948 -0.796739,-0.90092 -0.796739,-2.54343 0,-1.68541 0.808996,-2.60473 0.815125,-0.91931 2.316672,-0.91931 0.484172,0 0.968344,0.10419 0.484172,0.10419 0.759967,0.24515 l -0.312567,0.86416 q -0.337082,-0.13484 -0.735452,-0.22064 -0.398369,-0.0919 -0.704807,-0.0919 -2.047006,0 -2.047006,2.61085 0,1.23801 0.496429,1.89992 0.502559,0.6619 1.48316,0.6619 0.839641,0 1.722182,-0.36159 l 0,0.90092 q -0.674163,0.34934 -1.697667,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5116"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.400681,-457.63349 q 0.263537,-0.37385 0.802868,-0.9806 l 2.169581,-2.29828 1.207366,0 -2.72117,2.86213 2.911162,3.85499 -1.231881,0 -2.371831,-3.1747 -0.766095,0.66191 0,2.51279 -1.005117,0 0,-9.53635 1.005117,0 0,5.05622 q 0,0.33709 -0.04903,1.04189 l 0.04903,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5118"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.827724,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151195,-0.95609 1.262525,0 1.997973,0.83351 0.73546,0.82739 0.73546,2.18797 l 0,0.64352 -4.62722,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145063,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808997,0 -1.293169,0.52707 -0.478043,0.52708 -0.563846,1.45865 l 3.511785,0 q 0,-0.96222 -0.429018,-1.47091 -0.429013,-0.51481 -1.225752,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5120"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.09032,-461.03495 q 0.4474,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5122"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.1394,-462.35263 q -1.47703,0 -2.33506,0.98673 -0.8519,0.9806 -0.8519,2.69052 0,1.75896 0.82126,2.72117 0.82738,0.95609 2.35344,0.95609 0.9377,0 2.13894,-0.33708 l 0,0.91318 q -0.93157,0.34934 -2.29828,0.34934 -1.97959,0 -3.05826,-1.20123 -1.07253,-1.20124 -1.07253,-3.41372 0,-1.3851 0.51482,-2.42699 0.52094,-1.04189 1.49541,-1.60574 0.98061,-0.56384 2.30442,-0.56384 1.40961,0 2.46376,0.51481 l -0.44127,0.8948 q -1.01737,-0.47804 -2.03475,-0.47804 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5124"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 121.86575,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99898,0 1.5138,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5126"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 128.23965,-454.19525 0,-4.34529 q 0,-0.82126 -0.37386,-1.22576 -0.37385,-0.40449 -1.17059,-0.40449 -1.05415,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.31256,-0.49643 0.87641,-0.76609 0.56385,-0.2758 1.2564,-0.2758 1.21349,0 1.82637,0.58836 0.61287,0.58223 0.61287,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5128"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 135.67385,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.9612,0.50868 -1.33607,0 -2.08378,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55772,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.33708,-0.28193 -1.32381,-0.66191 -0.93771,-0.34934 -1.33607,-0.60675 -0.39225,-0.26353 -0.58837,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66804,-1.29317 0.66803,-0.47804 1.8325,-0.47804 1.08479,0 2.12055,0.44127 l -0.3616,0.82738 q -1.01124,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36772,0.22677 -0.36772,0.62514 0,0.26966 0.13483,0.45965 0.14096,0.19 0.4474,0.3616 0.30644,0.17161 1.17672,0.49643 1.19511,0.43514 1.61187,0.87641 0.42288,0.44127 0.42288,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5130"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.49206,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5132"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.82408,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14096,0.94383 q -0.41676,-0.0919 -0.73545,-0.0919 -0.81513,0 -1.39736,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37385,-0.65577 0.90092,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5134"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 147.83943,-460.91237 0,4.35755 q 0,0.82125 0.37385,1.22575 0.37386,0.4045 1.1706,0.4045 1.05414,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31257,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83863,-0.58223 -0.60674,-0.58223 -0.60674,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5136"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 157.26546,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5138"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.73232,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25127,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.49031,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5140"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 170.79777,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5142"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 175.6395,-461.03495 q 0.44739,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81513,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01738,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5144"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 182.90822,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85802,0.6619 -2.32893,0.6619 -1.59348,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55159,0.23289 1.20124,0.36773 0.64964,0.13483 1.28704,0.13483 1.04188,0 1.56896,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62513,-0.55158 -0.43515,-0.25128 -1.32994,-0.56998 -1.25027,-0.4474 -1.7896,-1.06027 -0.53321,-0.61288 -0.53321,-1.59961 0,-1.03576 0.77836,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45763,0.4903 l -0.32482,0.90705 q -1.10931,-0.46578 -2.15732,-0.46578 -0.82739,0 -1.29317,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40961,0.50256 1.93669,1.07866 0.5332,0.57611 0.5332,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5146"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.71314,-454.07268 q -0.65578,0 -1.20123,-0.23902 -0.53934,-0.24515 -0.90706,-0.74771 l -0.0736,0 q 0.0736,0.58836 0.0736,1.11544 l 0,2.76407 -1.01738,0 0,-9.73247 0.82739,0 0.14096,0.91931 0.049,0 q 0.39224,-0.55159 0.91318,-0.79674 0.52095,-0.24515 1.19511,-0.24515 1.33607,0 2.05927,0.91319 0.72932,0.91318 0.72932,2.56182 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.04701,0.91318 z m -0.14709,-6.09811 q -1.02963,0 -1.48929,0.56997 -0.45965,0.56998 -0.47191,1.81411 l 0,0.22677 q 0,1.41574 0.47191,2.02862 0.47192,0.60675 1.51381,0.60675 0.87028,0 1.36058,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.4903,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5148"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 195.12281,-454.07268 q -1.48929,0 -2.35344,-0.90705 -0.85803,-0.90706 -0.85803,-2.51892 0,-1.62413 0.79674,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99797,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62721,0 q 0.0306,1.18285 0.59449,1.79573 0.56997,0.61287 1.59961,0.61287 1.08479,0 2.14506,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.47804,0.10419 -1.15834,0.10419 z m -0.27579,-6.11037 q -0.809,0 -1.29317,0.52707 -0.47804,0.52708 -0.56385,1.45865 l 3.51179,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5150"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.00542,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5152"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.694,-454.19525 -0.20225,-0.95609 -0.049,0 q -0.50256,0.63126 -1.00512,0.85803 -0.49643,0.22063 -1.24414,0.22063 -0.99899,0 -1.56896,-0.51481 -0.56385,-0.51482 -0.56385,-1.46478 0,-2.03474 3.25438,-2.13281 l 1.13995,-0.0368 0,-0.41675 q 0,-0.79061 -0.34321,-1.16447 -0.33709,-0.37998 -1.0848,-0.37998 -0.83964,0 -1.89991,0.51481 l -0.31257,-0.77835 q 0.49643,-0.26966 1.08479,-0.42288 0.59449,-0.15322 1.18898,-0.15322 1.20124,0 1.77734,0.5332 0.58224,0.5332 0.58224,1.70992 l 0,4.58432 -0.75384,0 z m -2.29829,-0.71707 q 0.94996,0 1.48929,-0.52094 0.54546,-0.52095 0.54546,-1.45865 l 0,-0.60674 -1.01737,0.0429 q -1.2135,0.0429 -1.75283,0.37998 -0.5332,0.33095 -0.5332,1.03576 0,0.55159 0.33095,0.83964 0.33708,0.28805 0.9377,0.28805 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5154"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 217.71958,-454.91232 q 0.26967,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16547,0.0797 -0.4903,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94894,0 0,0.79061 -1.94894,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5156"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 228.74522,-460.91237 0,0.64352 -1.24414,0.14709 q 0.17161,0.2145 0.30644,0.56384 0.13483,0.34321 0.13483,0.77835 0,0.98674 -0.67416,1.5751 -0.67416,0.58836 -1.85089,0.58836 -0.30031,0 -0.56384,-0.049 -0.64965,0.34321 -0.64965,0.86415 0,0.2758 0.22676,0.41063 0.22677,0.1287 0.77836,0.1287 l 1.18898,0 q 1.09091,0 1.67315,0.45966 0.58836,0.45966 0.58836,1.33607 0,1.11544 -0.8948,1.69767 -0.8948,0.58836 -2.61085,0.58836 -1.31769,0 -2.03475,-0.4903 -0.71094,-0.4903 -0.71094,-1.3851 0,-0.61288 0.39224,-1.06028 0.39224,-0.4474 1.10318,-0.60674 -0.25741,-0.11645 -0.43514,-0.3616 -0.17161,-0.24515 -0.17161,-0.56998 0,-0.36772 0.19612,-0.64352 0.19612,-0.27579 0.61901,-0.5332 -0.52095,-0.21451 -0.8519,-0.72932 -0.32483,-0.51482 -0.32483,-1.17672 0,-1.10318 0.66191,-1.69767 0.66191,-0.60062 1.8754,-0.60062 0.52708,0 0.94996,0.12258 l 2.3228,0 z m -5.35654,7.84481 q 0,0.54546 0.45966,0.82738 0.45966,0.28193 1.31768,0.28193 1.28092,0 1.89379,-0.38612 0.61901,-0.37998 0.61901,-1.03576 0,-0.54546 -0.33709,-0.75996 -0.33708,-0.20838 -1.26865,-0.20838 l -1.21962,0 q -0.69255,0 -1.07866,0.33095 -0.38612,0.33096 -0.38612,0.94996 z m 0.55159,-5.69362 q 0,0.70481 0.39837,1.06641 0.39837,0.36159 1.10931,0.36159 1.48929,0 1.48929,-1.44639 0,-1.5138 -1.50768,-1.5138 -0.71706,0 -1.10318,0.38611 -0.38611,0.38611 -0.38611,1.14608 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5158"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 231.15383,-454.19525 -1.01738,0 0,-6.71712 1.01738,0 0,6.71712 z m -1.10318,-8.53737 q 0,-0.34934 0.17161,-0.50868 0.1716,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.25741,0 -0.42901,-0.16548 -0.17161,-0.17161 -0.17161,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5160"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 235.49299,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5162"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 242.3572,-454.19525 0,-4.34529 q 0,-0.82126 -0.37385,-1.22576 -0.37386,-0.40449 -1.1706,-0.40449 -1.06027,0 -1.55057,0.5761 -0.48417,0.5761 -0.48417,1.88766 l 0,3.51178 -1.01738,0 0,-9.53635 1.01738,0 0,2.88664 q 0,0.52095 -0.049,0.86416 l 0.0613,0 q 0.30031,-0.48417 0.8519,-0.75997 0.55772,-0.28192 1.26865,-0.28192 1.23189,0 1.84476,0.58836 0.61901,0.58223 0.61901,1.85701 l 0,4.38207 -1.01738,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5164"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 246.41444,-460.91237 0,4.35755 q 0,0.82125 0.37386,1.22575 0.37385,0.4045 1.17059,0.4045 1.05415,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31256,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83862,-0.58223 -0.60675,-0.58223 -0.60675,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5166"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 256.28175,-461.02269 q 1.32381,0 2.05313,0.90705 0.73545,0.90093 0.73545,2.5557 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.047,0.91318 -0.65578,0 -1.20124,-0.23902 -0.53933,-0.24515 -0.90706,-0.74771 l -0.0735,0 -0.21451,0.86416 -0.72932,0 0,-9.53635 1.01737,0 0,2.31667 q 0,0.77835 -0.049,1.39736 l 0.049,0 q 0.71094,-1.00512 2.1083,-1.00512 z m -0.14709,0.8519 q -1.04189,0 -1.50155,0.60061 -0.45966,0.59449 -0.45966,2.01024 0,1.41574 0.47192,2.02862 0.47191,0.60675 1.5138,0.60675 0.9377,0 1.39736,-0.6803 0.45966,-0.68642 0.45966,-1.96733 0,-1.31155 -0.45966,-1.95507 -0.45966,-0.64352 -1.42187,-0.64352 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5168"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 260.70671,-454.8449 q 0,-0.41063 0.18386,-0.61901 0.19,-0.2145 0.53933,-0.2145 0.35547,0 0.55159,0.2145 0.20225,0.20838 0.20225,0.61901 0,0.39837 -0.20225,0.61288 -0.20225,0.2145 -0.55159,0.2145 -0.31256,0 -0.52094,-0.18999 -0.20225,-0.19612 -0.20225,-0.63739 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5170"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.87224,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5172"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 275.96731,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5174"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.30655,-454.19525 0,-4.36981 q 0,-0.80287 -0.34321,-1.20124 -0.34321,-0.40449 -1.06641,-0.40449 -0.94995,0 -1.40348,0.54546 -0.45353,0.54546 -0.45353,1.67928 l 0,3.7508 -1.01737,0 0,-4.36981 q 0,-0.80287 -0.34322,-1.20124 -0.34321,-0.40449 -1.07253,-0.40449 -0.95609,0 -1.40348,0.5761 -0.44128,0.56997 -0.44128,1.8754 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.28805,-0.4903 0.809,-0.76609 0.52707,-0.2758 1.17672,-0.2758 1.57509,0 2.05926,1.13995 l 0.049,0 q 0.30031,-0.52707 0.87029,-0.83351 0.56997,-0.30644 1.29929,-0.30644 1.13995,0 1.7038,0.58836 0.56997,0.58223 0.56997,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5176"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 292.81529,-463.1555 -3.34017,8.96025 -1.01738,0 3.34018,-8.96025 1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5178"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 296.19224,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5180"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 301.2975,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79673,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53934,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29317,0.52707 -0.47804,0.52708 -0.56384,1.45865 l 3.51178,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5182"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 308.56009,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14097,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5184"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 311.63671,-454.19525 -1.01738,0 0,-6.71712 1.01738,0 0,6.71712 z m -1.10318,-8.53737 q 0,-0.34934 0.17161,-0.50868 0.1716,-0.16548 0.42901,-0.16548 0.24515,0 0.42288,0.16548 0.17774,0.16547 0.17774,0.50868 0,0.34321 -0.17774,0.51482 -0.17773,0.16548 -0.42288,0.16548 -0.25741,0 -0.42901,-0.16548 -0.17161,-0.17161 -0.17161,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5186"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 318.40286,-454.19525 0,-4.34529 q 0,-0.82126 -0.37386,-1.22576 -0.37385,-0.40449 -1.17059,-0.40449 -1.05415,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16547,0.91931 0.049,0 q 0.31257,-0.49643 0.87642,-0.76609 0.56384,-0.2758 1.25639,-0.2758 1.2135,0 1.82637,0.58836 0.61288,0.58223 0.61288,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5188"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 320.68888,-451.1799 q -0.58223,0 -0.94383,-0.15322 l 0,-0.82738 q 0.42289,0.12257 0.83352,0.12257 0.47804,0 0.69867,-0.26353 0.22677,-0.25741 0.22677,-0.79061 l 0,-7.8203 1.01737,0 0,7.74675 q 0,1.98572 -1.8325,1.98572 z m 0.72933,-11.55272 q 0,-0.34934 0.1716,-0.50868 0.17161,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.2574,0 -0.42901,-0.16548 -0.1716,-0.17161 -0.1716,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5190"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 330.4888,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82739,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82125,-0.91931 2.2799,-0.91931 1.40961,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11752,0 q 0,1.28704 0.51482,1.9612 0.51481,0.67417 1.5138,0.67417 0.99899,0 1.51381,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52607,-0.66803 -0.99898,0 -1.50767,0.65577 -0.50869,0.65578 -0.50869,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5192"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 333.27124,-457.63349 q 0.26354,-0.37385 0.80287,-0.9806 l 2.16958,-2.29828 1.20737,0 -2.72117,2.86213 2.91116,3.85499 -1.23188,0 -2.37183,-3.1747 -0.7661,0.66191 0,2.51279 -1.00512,0 0,-9.53635 1.00512,0 0,5.05622 q 0,0.33709 -0.049,1.04189 l 0.049,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5194"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 341.69828,-454.07268 q -1.48929,0 -2.35344,-0.90705 -0.85803,-0.90706 -0.85803,-2.51892 0,-1.62413 0.79674,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99797,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62721,0 q 0.0306,1.18285 0.59449,1.79573 0.56997,0.61287 1.59961,0.61287 1.08479,0 2.14506,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.47804,0.10419 -1.15834,0.10419 z m -0.27579,-6.11037 q -0.809,0 -1.29317,0.52707 -0.47804,0.52708 -0.56385,1.45865 l 3.51179,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5196"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.22953,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.9612,0.50868 -1.33607,0 -2.08378,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55772,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.33709,-0.28193 -1.32382,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.39224,-0.26353 -0.58836,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66804,-1.29317 0.66803,-0.47804 1.8325,-0.47804 1.08479,0 2.12055,0.44127 l -0.3616,0.82738 q -1.01124,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36772,0.22677 -0.36772,0.62514 0,0.26966 0.13483,0.45965 0.14096,0.19 0.4474,0.3616 0.30644,0.17161 1.17672,0.49643 1.19511,0.43514 1.61186,0.87641 0.42289,0.44127 0.42289,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5198"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 355.27962,-463.1555 -3.34018,8.96025 -1.01737,0 3.34017,-8.96025 1.01738,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5200"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 361.69643,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85803,0.6619 -2.32893,0.6619 -1.59348,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55158,0.23289 1.20123,0.36773 0.64965,0.13483 1.28704,0.13483 1.04189,0 1.56897,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62514,-0.55158 -0.43514,-0.25128 -1.32994,-0.56998 -1.25026,-0.4474 -1.7896,-1.06027 -0.5332,-0.61288 -0.5332,-1.59961 0,-1.03576 0.77836,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45763,0.4903 l -0.32482,0.90705 q -1.10931,-0.46578 -2.15733,-0.46578 -0.82738,0 -1.29316,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40961,0.50256 1.93668,1.07866 0.53321,0.57611 0.53321,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5202"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 365.54529,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.57611,0.0552 -1.94894,0 -1.94894,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28806,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5204"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.83031,-454.19525 -1.01737,0 0,-6.71712 1.01737,0 0,6.71712 z m -1.10317,-8.53737 q 0,-0.34934 0.1716,-0.50868 0.17161,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.2574,0 -0.42901,-0.16548 -0.1716,-0.17161 -0.1716,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5206"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.68429,-454.07268 q -1.45865,0 -2.26152,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81513,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31256,0.86416 q -0.33709,-0.13484 -0.73546,-0.22064 -0.39836,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69766,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5208"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 377.98669,-457.63349 q 0.26354,-0.37385 0.80287,-0.9806 l 2.16958,-2.29828 1.20737,0 -2.72117,2.86213 2.91116,3.85499 -1.23188,0 -2.37183,-3.1747 -0.7661,0.66191 0,2.51279 -1.00511,0 0,-9.53635 1.00511,0 0,5.05622 q 0,0.33709 -0.049,1.04189 l 0.049,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5210"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 386.41374,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79674,-2.58021 0.80286,-0.95609 2.15119,-0.95609 1.26253,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29316,0.52707 -0.47805,0.52708 -0.56385,1.45865 l 3.51178,0 q 0,-0.96222 -0.42901,-1.47091 -0.42902,-0.51481 -1.22576,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5212"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 393.6763,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14096,0.94383 q -0.41676,-0.0919 -0.73546,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37385,-0.65577 0.90092,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5214"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.41997,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5216"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 407.51504,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5218"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 413.88897,-454.19525 0,-4.34529 q 0,-0.82126 -0.37385,-1.22576 -0.37386,-0.40449 -1.1706,-0.40449 -1.05414,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.31257,-0.49643 0.87641,-0.76609 0.56385,-0.2758 1.2564,-0.2758 1.21349,0 1.82637,0.58836 0.61287,0.58223 0.61287,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5220"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 421.32316,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.96121,0.50868 -1.33607,0 -2.08377,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55771,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34322,-0.66803 -0.33708,-0.28193 -1.32381,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.39224,-0.26353 -0.58836,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66803,-1.29317 0.66804,-0.47804 1.8325,-0.47804 1.0848,0 2.12056,0.44127 l -0.3616,0.82738 q -1.01125,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36773,0.22677 -0.36773,0.62514 0,0.26966 0.13484,0.45965 0.14096,0.19 0.4474,0.3616 0.30643,0.17161 1.17672,0.49643 1.19511,0.43514 1.61186,0.87641 0.42289,0.44127 0.42289,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5222"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.14136,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.57611,0.0552 -1.94894,0 -1.94894,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5224"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 430.47342,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14097,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5226"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 433.48872,-460.91237 0,4.35755 q 0,0.82125 0.37386,1.22575 0.37385,0.4045 1.17059,0.4045 1.05415,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31256,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83862,-0.58223 -0.60675,-0.58223 -0.60675,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5228"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 442.91479,-454.07268 q -1.45865,0 -2.26152,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81513,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31256,0.86416 q -0.33709,-0.13484 -0.73546,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69766,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5230"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 448.38166,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16547,0.0797 -0.4903,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94894,0 0,0.79061 -1.94894,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5232"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 456.44708,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82739,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11752,0 q 0,1.28704 0.51482,1.9612 0.51482,0.67417 1.5138,0.67417 0.99899,0 1.51381,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50869,0.65578 -0.50869,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5234"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.28879,-461.03495 q 0.4474,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5236"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.55751,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85802,0.6619 -2.32893,0.6619 -1.59347,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55159,0.23289 1.20124,0.36773 0.64965,0.13483 1.28704,0.13483 1.04189,0 1.56896,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62513,-0.55158 -0.43514,-0.25128 -1.32994,-0.56998 -1.25027,-0.4474 -1.7896,-1.06027 -0.5332,-0.61288 -0.5332,-1.59961 0,-1.03576 0.77835,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45764,0.4903 l -0.32483,0.90705 q -1.1093,-0.46578 -2.15732,-0.46578 -0.82738,0 -1.29317,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40962,0.50256 1.93669,1.07866 0.5332,0.57611 0.5332,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5238"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 473.36246,-454.07268 q -0.65577,0 -1.20123,-0.23902 -0.53933,-0.24515 -0.90706,-0.74771 l -0.0735,0 q 0.0735,0.58836 0.0735,1.11544 l 0,2.76407 -1.01737,0 0,-9.73247 0.82738,0 0.14096,0.91931 0.049,0 q 0.39224,-0.55159 0.91319,-0.79674 0.52094,-0.24515 1.1951,-0.24515 1.33607,0 2.05927,0.91319 0.72932,0.91318 0.72932,2.56182 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.04701,0.91318 z m -0.14709,-6.09811 q -1.02963,0 -1.48928,0.56997 -0.45966,0.56998 -0.47192,1.81411 l 0,0.22677 q 0,1.41574 0.47192,2.02862 0.47191,0.60675 1.5138,0.60675 0.87028,0 1.36058,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.4903,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5240"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 480.77217,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79673,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26253,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29317,0.52707 -0.47804,0.52708 -0.56384,1.45865 l 3.51178,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5242"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 487.65471,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5244"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 493.08482,-457.63349 q 0,1.61187 -0.47805,3.0031 -0.47191,1.39123 -1.36671,2.42086 l -0.9806,0 q 0.85189,-1.15221 1.30542,-2.5557 0.45353,-1.40961 0.45353,-2.88051 0,-1.49542 -0.4474,-2.91117 -0.44127,-1.41574 -1.32381,-2.59859 l 0.99286,0 q 0.90093,1.07253 1.37284,2.49441 0.47192,1.41574 0.47192,3.0276 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5246"
+         inkscape:connector-curvature="0" />
+    </g>
     <rect
        transform="translate(178.67433,582.63783)"
        style="opacity:1;fill:none;fill-opacity:1;stroke:#0093d9;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000003, 4.00000005;stroke-dashoffset:6.5;stroke-opacity:1"
@@ -118,91 +728,978 @@
        height="21.23"
        x="38.762836"
        y="69.453773" />
-    <text
-       xml:space="preserve"
+    <g
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="255.83966"
-       y="580.09589"
-       id="text8536"
-       sodipodi:linespacing="521%"><tspan
-         sodipodi:role="line"
-         id="tspan8538"
-         x="255.83966"
-         y="580.09589"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Safe area <tspan
-   style="font-weight:normal"
-   id="tspan8540">- Keep all text inside this border</tspan></tspan></text>
-    <text
-       sodipodi:linespacing="521%"
-       id="text8542"
-       y="624.09589"
-       x="255.83966"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+       id="text8536">
+      <path
+         d="m 263.32035,577.19507 q 0,1.41468 -1.02172,2.2292 -1.01457,0.81451 -2.82937,0.81451 -1.6719,0 -2.95798,-0.62875 l 0,-2.05772 q 1.05744,0.47156 1.78622,0.66447 0.73592,0.19292 1.34323,0.19292 0.72878,0 1.1146,-0.27865 0.39297,-0.27865 0.39297,-0.82881 0,-0.30723 -0.17147,-0.54301 -0.17148,-0.24293 -0.50729,-0.46442 -0.32866,-0.22149 -1.35038,-0.70734 -0.95741,-0.45013 -1.43612,-0.86453 -0.47871,-0.4144 -0.7645,-0.96456 -0.2858,-0.55015 -0.2858,-1.28608 0,-1.3861 0.93598,-2.17918 0.94312,-0.79308 2.60074,-0.79308 0.81451,0 1.55043,0.19291 0.74307,0.19291 1.55044,0.54301 l -0.71449,1.72191 q -0.83595,-0.34295 -1.3861,-0.4787 -0.54301,-0.13576 -1.07173,-0.13576 -0.62875,0 -0.96456,0.29294 -0.33581,0.29294 -0.33581,0.76451 0,0.29294 0.13575,0.51443 0.13575,0.21434 0.42869,0.42154 0.30009,0.20006 1.40754,0.72878 1.4647,0.7002 2.00771,1.40754 0.54302,0.7002 0.54302,1.72192 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="624.09589"
-         x="255.83966"
-         id="tspan8544"
-         sodipodi:role="line">Trim <tspan
-   id="tspan8546"
-   style="font-weight:normal">- Outer edge of sticker</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="255.83966"
-       y="668.09589"
-       id="text8548"
-       sodipodi:linespacing="521%"><tspan
-         sodipodi:role="line"
-         id="tspan8550"
-         x="255.83966"
-         y="668.09589"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
-           style="font-weight:normal"
-           id="tspan8552"><tspan
-   style="font-weight:bold"
-   id="tspan8554">Bleed</tspan> - This area will be trimmed off</tspan></tspan></text>
-    <text
-       sodipodi:linespacing="521%"
-       id="text8556"
-       y="748.41248"
-       x="326.5592"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+         id="path4978"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.11512,580.09589 -0.42155,-1.08602 -0.0572,0 q -0.55016,0.69305 -1.13604,0.96455 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88596,-1.87196 0.89311,-0.60731 2.68648,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.24321,-1.21462 -0.95741,0 -2.25063,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.058,-0.72164 1.6076,0 2.46499,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46441,0.31438 -0.46441,0.95742 0,0.92169 1.05744,0.92169 0.75735,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="748.41248"
-         x="326.5592"
-         id="tspan8558"
-         sodipodi:role="line">Make sure you:</tspan></text>
-    <text
-       xml:space="preserve"
+         id="path4980"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 278.28886,573.74409 -1.88625,0 0,6.3518 -2.17918,0 0,-6.3518 -1.20034,0 0,-1.05029 1.20034,-0.58588 0,-0.58588 q 0,-1.36468 0.67161,-1.99342 0.67162,-0.62875 2.15061,-0.62875 1.12889,0 2.00771,0.33581 l -0.5573,1.60045 q -0.65733,-0.2072 -1.21463,-0.2072 -0.46441,0 -0.67162,0.27865 -0.2072,0.2715 -0.2072,0.70019 l 0,0.50015 1.88625,0 0,1.63617 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4982"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 282.84014,573.50831 q -0.69305,0 -1.08602,0.44298 -0.39296,0.43584 -0.45012,1.24321 l 3.058,0 q -0.0143,-0.80737 -0.42154,-1.24321 -0.40726,-0.44298 -1.10032,-0.44298 z m 0.30723,6.73047 q -1.92911,0 -3.01513,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63645,0.96456 0.94313,0.96456 0.94313,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92884 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72164,0 1.36467,-0.15005 0.64304,-0.15004 1.34324,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65019,0.14289 -1.58617,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4984"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 297.06559,580.09589 -0.42154,-1.08602 -0.0572,0 q -0.55016,0.69305 -1.13604,0.96455 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88597,-1.87196 0.89311,-0.60731 2.68647,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.2432,-1.21462 -0.95742,0 -2.25064,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.05801,-0.72164 1.60759,0 2.46498,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46441,0.31438 -0.46441,0.95742 0,0.92169 1.05744,0.92169 0.75736,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4986"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 305.2822,571.95787 q 0.44298,0 0.73592,0.0643 l -0.16433,2.04343 q -0.26436,-0.0715 -0.64304,-0.0715 -1.04315,0 -1.62903,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98797 1.65046,0 0.32152,1.34323 0.10718,0 q 0.37153,-0.67162 1.00028,-1.07887 0.63589,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4988"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 310.7909,573.50831 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92884 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4990"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 321.21527,580.09589 -0.42155,-1.08602 -0.0572,0 q -0.55015,0.69305 -1.13603,0.96455 -0.57874,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88596,-1.87196 0.89311,-0.60731 2.68648,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.24321,-1.21462 -0.95741,0 -2.25063,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.058,-0.72164 1.6076,0 2.46498,0.7002 0.85739,0.7002 0.85739,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46442,0.31438 -0.46442,0.95742 0,0.92169 1.05745,0.92169 0.75735,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4992"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 328.23154,576.71636 0,-1.08602 3.50813,0 0,1.08602 -3.50813,0 z"
+         style="font-weight:normal"
+         id="path4994"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 345.12917,580.09589 -1.42897,0 -3.80822,-5.06572 -1.09317,0.9717 0,4.09402 -1.21463,0 0,-10.44581 1.21463,0 0,5.18003 4.73705,-5.18003 1.43612,0 -4.20118,4.53699 4.35837,5.90882 z"
+         style="font-weight:normal"
+         id="path4996"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 349.6876,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50015,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path4998"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 357.88992,580.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92884,-3.00799 0.93597,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86482,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5000"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 366.42804,580.23878 q -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 q 0.0857,0.68591 0.0857,1.30037 l 0,3.22233 -1.18604,0 0,-11.34606 0.96455,0 0.16434,1.07173 0.0571,0 q 0.45728,-0.64303 1.06459,-0.92883 0.60732,-0.28579 1.39325,-0.28579 1.55758,0 2.40068,1.06458 0.85024,1.06459 0.85024,2.98656 0,1.92912 -0.86453,3.00085 -0.85739,1.06458 -2.38639,1.06458 z m -0.17148,-7.10915 q -1.20033,0 -1.7362,0.66448 -0.53587,0.66447 -0.55016,2.11488 l 0,0.26436 q 0,1.65047 0.55016,2.36495 0.55016,0.70735 1.76478,0.70735 1.01458,0 1.58617,-0.82166 0.57873,-0.82167 0.57873,-2.26493 0,-1.4647 -0.57873,-2.24349 -0.57159,-0.78594 -1.61475,-0.78594 z"
+         style="font-weight:normal"
+         id="path5002"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 380.37484,580.09589 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25721 -1.45041,0.25721 -1.16461,0 -1.82909,-0.60017 -0.65732,-0.60017 -0.65732,-1.70762 0,-2.3721 3.79392,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26465,-0.44299 -0.97884,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.49299 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60732 0.63589,-0.60731 0.63589,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.62161,0.38583 -0.62161,1.20749 0,0.64304 0.38583,0.97885 0.39296,0.33581 1.09316,0.33581 z"
+         style="font-weight:normal"
+         id="path5004"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 384.8904,580.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5006"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.60573,580.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5008"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 397.46539,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5010"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 403.41706,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5012"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 410.19755,576.08761 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05772,-3.00085 1.3361,0 -2.7222,3.82251 2.86509,4.00828 -1.34323,0 -2.19348,-3.17233 -2.21491,3.17233 -1.34324,0 2.8651,-4.00828 z"
+         style="font-weight:normal"
+         id="path5014"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 418.49989,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5016"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.13062,580.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5018"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 434.01856,580.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66448 -0.57159,0.66447 -0.57159,2.19347 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02172,-0.89311 0.65733,-0.32151 1.4647,-0.32151 1.41468,0 2.12917,0.6859 0.71449,0.67877 0.71449,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5020"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 442.6853,577.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56445,0.28579 1.20749,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.17891,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path5022"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 445.79332,580.09589 -1.18604,0 0,-7.83079 1.18604,0 0,7.83079 z m -1.28607,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-weight:normal"
+         id="path5024"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 453.65268,579.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53614,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.37209,0.20006 q 1.21462,0 1.75764,-0.65733 0.55015,-0.66448 0.55015,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76478,-0.71449 -1.04316,0 -1.60046,0.81452 -0.55015,0.80737 -0.55015,2.28636 0,1.50042 0.55015,2.26492 0.55016,0.76451 1.61475,0.76451 z"
+         style="font-weight:normal"
+         id="path5026"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 460.60465,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.55731,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5028"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 471.82925,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5030"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 479.8315,580.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18604,0 0,-11.11743 1.18604,0 0,3.36524 q 0,0.60731 -0.0571,1.00742 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65019,-0.32866 1.47899,-0.32866 1.43612,0 2.15061,0.6859 0.72163,0.67877 0.72163,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5032"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 484.63286,580.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28607,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-weight:normal"
+         id="path5034"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 492.21357,577.95957 q 0,1.09316 -0.81451,1.68619 -0.81452,0.59302 -2.28636,0.59302 -1.55759,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56444,0.28579 1.20748,0.45012 0.65019,0.16434 1.25036,0.16434 0.92883,0 1.42897,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.54329,-0.77165 -1.09317,-0.40726 -1.55759,-0.70734 -0.45727,-0.30723 -0.6859,-0.69306 -0.2215,-0.38582 -0.2215,-0.92169 0,-0.95741 0.7788,-1.50756 0.77879,-0.5573 2.13631,-0.5573 1.26465,0 2.47213,0.51443 l -0.42155,0.96455 q -1.1789,-0.48585 -2.13631,-0.48585 -0.8431,0 -1.27179,0.26436 -0.4287,0.26436 -0.4287,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52158,0.42154 0.35724,0.20006 1.37181,0.57874 1.39325,0.50729 1.87911,1.02172 0.49299,0.51443 0.49299,1.29322 z"
+         style="font-weight:normal"
+         id="path5036"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 501.58051,572.1365 q 1.54329,0 2.39353,1.05744 0.85739,1.05029 0.85739,2.97941 0,1.92912 -0.86453,3.00085 -0.85739,1.06458 -2.38639,1.06458 -0.7645,0 -1.4004,-0.27865 -0.62875,-0.28579 -1.05744,-0.87167 l -0.0857,0 -0.25007,1.00743 -0.85024,0 0,-11.11743 1.18605,0 0,2.70076 q 0,0.9074 -0.0572,1.62903 l 0.0572,0 q 0.82881,-1.17175 2.45784,-1.17175 z m -0.17148,0.99313 q -1.21463,0 -1.75049,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65047 0.55016,2.36495 0.55015,0.70735 1.76478,0.70735 1.09317,0 1.62903,-0.79309 0.53587,-0.80022 0.53587,-2.2935 0,-1.529 -0.53587,-2.27922 -0.53586,-0.75021 -1.65761,-0.75021 z"
+         style="font-weight:normal"
+         id="path5038"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 513.66964,576.17335 q 0,1.91483 -0.96456,2.9937 -0.96455,1.07173 -2.66504,1.07173 -1.05029,0 -1.86481,-0.49299 -0.81451,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09316 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75763,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-weight:normal"
+         id="path5040"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 519.3141,572.12221 q 0.52157,0 0.93598,0.0857 l -0.16434,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61445,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5042"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 527.04485,579.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53615,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55016,-0.66448 0.55016,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76479,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55016,0.80737 -0.55016,2.28636 0,1.50042 0.55016,2.26492 0.55016,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path5044"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 533.99682,580.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5046"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 542.46348,572.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5048"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8542">
+      <path
+         d="m 261.18403,624.09589 -2.21491,0 0,-8.60243 -2.83652,0 0,-1.84338 7.88794,0 0,1.84338 -2.83651,0 0,8.60243 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4931"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 269.92935,615.95787 q 0.44299,0 0.73593,0.0643 l -0.16434,2.04343 q -0.26436,-0.0715 -0.64303,-0.0715 -1.04316,0 -1.62904,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98797 1.65047,0 0.32152,1.34323 0.10717,0 q 0.37153,-0.67162 1.00028,-1.07887 0.6359,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4933"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.03709,614.04305 q 0,-1.06459 1.18605,-1.06459 1.18605,0 1.18605,1.06459 0,0.50728 -0.30008,0.79308 -0.29294,0.27865 -0.88597,0.27865 -1.18605,0 -1.18605,-1.07173 z m 2.27207,10.05284 -2.17918,0 0,-7.98797 2.17918,0 0,7.98797 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4935"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.7404,624.09589 -2.17919,0 0,-4.66561 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.83595,0 -1.21463,0.61446 -0.37867,0.61446 -0.37867,2.022 l 0,3.75821 -2.17919,0 0,-7.98797 1.66475,0 0.29294,1.02171 0.12147,0 q 0.32152,-0.55015 0.92883,-0.85738 0.60732,-0.31438 1.39325,-0.31438 1.79337,0 2.42926,1.17176 l 0.19291,0 q 0.32152,-0.5573 0.94312,-0.86453 0.62875,-0.30723 1.41469,-0.30723 1.35753,0 2.05058,0.7002 0.7002,0.69305 0.7002,2.2292 l 0,5.20862 -2.18634,0 0,-4.66561 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.90739,-0.43584 -0.80023,0 -1.20034,0.57159 -0.39297,0.57159 -0.39297,1.8148 l 0,4.00828 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4937"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 294.22193,620.71636 0,-1.08602 3.50813,0 0,1.08602 -3.50813,0 z"
+         style="font-weight:normal"
+         id="path4939"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 312.64142,618.85869 q 0,2.50785 -1.27179,3.94397 -1.26464,1.43612 -3.52242,1.43612 -2.3078,0 -3.5653,-1.40754 -1.25035,-1.41468 -1.25035,-3.98684 0,-2.55072 1.2575,-3.95111 1.2575,-1.40754 3.57244,-1.40754 2.25063,0 3.51527,1.42897 1.26465,1.42898 1.26465,3.94397 z m -8.32378,0 q 0,2.12203 0.90025,3.22234 0.9074,1.09317 2.62932,1.09317 1.7362,0 2.62217,-1.09317 0.88596,-1.09316 0.88596,-3.22234 0,-2.10774 -0.88596,-3.19376 -0.87882,-1.09316 -2.60788,-1.09316 -1.73621,0 -2.64361,1.10031 -0.90025,1.09316 -0.90025,3.18661 z"
+         style="font-weight:normal"
+         id="path4941"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 315.91377,616.2651 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47157 1.36467,0.47157 1.22892,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17147,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47184,0.30723 -1.42898,0 -2.14347,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-weight:normal"
+         id="path4943"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 326.30242,623.25994 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19292,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.3358,0.37868 0.92168,0.37868 z"
+         style="font-weight:normal"
+         id="path4945"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.25411,624.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50786,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path4947"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 340.72078,616.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95026,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path4949"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.23061,624.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92884,-3.00799 0.93597,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86482,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path4951"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 360.45492,623.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53615,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55016,-0.66448 0.55016,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76479,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55015,0.80737 -0.55015,2.28636 0,1.50042 0.55015,2.26492 0.55016,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path4953"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 370.50777,616.2651 0,0.75021 -1.45041,0.17148 q 0.20005,0.25007 0.35724,0.65733 0.15719,0.40011 0.15719,0.9074 0,1.15032 -0.78594,1.83623 -0.78593,0.68591 -2.15775,0.68591 -0.3501,0 -0.65733,-0.0572 -0.75736,0.40011 -0.75736,1.00743 0,0.32152 0.26437,0.47871 0.26436,0.15004 0.90739,0.15004 l 1.38611,0 q 1.27179,0 1.95055,0.53586 0.68591,0.53587 0.68591,1.55759 0,1.30036 -1.04315,1.97913 -1.04315,0.6859 -3.04372,0.6859 -1.53615,0 -2.3721,-0.57159 -0.8288,-0.57159 -0.8288,-1.61474 0,-0.71448 0.45727,-1.23606 0.45727,-0.52158 1.28608,-0.70734 -0.30009,-0.13576 -0.50729,-0.42155 -0.20006,-0.2858 -0.20006,-0.66447 0,-0.4287 0.22864,-0.75022 0.22864,-0.32152 0.72163,-0.6216 -0.60731,-0.25007 -0.99314,-0.85024 -0.37867,-0.60017 -0.37867,-1.37182 0,-1.28607 0.77164,-1.97913 0.77165,-0.70019 2.18633,-0.70019 0.61446,0 1.10746,0.14289 l 2.70791,0 z m -6.24462,9.14544 q 0,0.6359 0.53586,0.96456 0.53587,0.32867 1.53615,0.32867 1.49328,0 2.20777,-0.45013 0.72163,-0.44298 0.72163,-1.20749 0,-0.63589 -0.39297,-0.88596 -0.39297,-0.24293 -1.47899,-0.24293 l -1.42183,0 q -0.80737,0 -1.2575,0.38583 -0.45012,0.38582 -0.45012,1.10745 z m 0.64304,-6.63759 q 0,0.82166 0.46441,1.24321 0.46442,0.42155 1.29322,0.42155 1.73621,0 1.73621,-1.68619 0,-1.76478 -1.75764,-1.76478 -0.83595,0 -1.28608,0.45012 -0.45012,0.45013 -0.45012,1.33609 z"
+         style="font-weight:normal"
+         id="path4955"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 375.43773,624.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50015,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path4957"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 390.8921,620.17335 q 0,1.91483 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.05029,0 -1.86481,-0.49299 -0.81452,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97941 0.95742,-1.07173 2.6579,-1.07173 1.64332,0 2.60788,1.09316 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75764,0.7645 -0.59302,0.76451 -0.59302,2.27922 z"
+         style="font-weight:normal"
+         id="path4959"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.49369,617.18679 -1.99342,0 0,6.9091 -1.18605,0 0,-6.9091 -1.4004,0 0,-0.53586 1.4004,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.6216,0 1.45755,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32151,0.44298 -0.32151,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z"
+         style="font-weight:normal"
+         id="path4961"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.78944,621.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42925,-0.49299 l 0,-1.10031 q 0.56444,0.28579 1.20748,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.1789,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path4963"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 411.2407,623.25994 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path4965"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 415.07035,624.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20005,-0.19291 0.50014,-0.19291 0.28579,0 0.49299,0.19291 0.20721,0.19291 0.20721,0.59302 0,0.40012 -0.20721,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path4967"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.7291,624.23878 q -1.70048,0 -2.63646,-1.04315 -0.92883,-1.05029 -0.92883,-2.96512 0,-1.96484 0.94312,-3.03657 0.95027,-1.07173 2.70076,-1.07173 0.56445,0 1.1289,0.12146 0.56444,0.12146 0.88596,0.28579 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85738,-0.25721 -0.46442,-0.10718 -0.82166,-0.10718 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57873,2.21491 0.58588,0.77165 1.72906,0.77165 0.97885,0 2.00771,-0.42155 l 0,1.0503 q -0.78593,0.40725 -1.97913,0.40725 z"
+         style="font-weight:normal"
+         id="path4969"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.74479,620.08761 q 0.30723,-0.43584 0.93598,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17233,3.33666 3.39382,4.49413 -1.43612,0 -2.76507,-3.70105 -0.89311,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-weight:normal"
+         id="path4971"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.56901,624.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path4973"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 444.03569,616.12221 q 0.52157,0 0.93597,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.4144 1.35039,-0.4144 z"
+         style="font-weight:normal"
+         id="path4975"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8548">
+      <path
+         d="m 257.15432,657.65008 3.25092,0 q 2.22205,0 3.22233,0.63589 1.00743,0.62875 1.00743,2.00771 0,0.93598 -0.44298,1.53615 -0.43584,0.60017 -1.16461,0.72163 l 0,0.0715 q 0.99313,0.22149 1.42897,0.82881 0.44298,0.60731 0.44298,1.61474 0,1.42897 -1.036,2.2292 -1.02887,0.80023 -2.8008,0.80023 l -3.90824,0 0,-10.44581 z m 2.21491,4.13688 1.28608,0 q 0.90025,0 1.30036,-0.27865 0.40726,-0.27865 0.40726,-0.92169 0,-0.60017 -0.44298,-0.85738 -0.43584,-0.26436 -1.38611,-0.26436 l -1.16461,0 0,2.32208 z m 0,1.75764 0,2.7222 1.44326,0 q 0.91455,0 1.35039,-0.3501 0.43583,-0.3501 0.43583,-1.07173 0,-1.30037 -1.85766,-1.30037 l -1.37182,0 z"
+         style="font-weight:bold"
+         id="path4872"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 268.99338,668.09589 -2.17919,0 0,-11.11743 2.17919,0 0,11.11743 z"
+         style="font-weight:bold"
+         id="path4874"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.58067,661.50831 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92884 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-weight:bold"
+         id="path4876"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.24026,661.50831 q -0.69306,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92884 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72164,0 1.36468,-0.15005 0.64303,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-weight:bold"
+         id="path4878"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 291.12106,668.23878 q -1.40755,0 -2.21492,-1.09316 -0.80022,-1.09317 -0.80022,-3.02943 0,-1.96484 0.81451,-3.05801 0.82166,-1.10031 2.25778,-1.10031 1.50757,0 2.30065,1.17176 l 0.0715,0 q -0.16433,-0.89311 -0.16433,-1.5933 l 0,-2.55787 2.18633,0 0,11.11743 -1.6719,0 -0.42155,-1.03601 -0.0929,0 q -0.74307,1.1789 -2.26492,1.1789 z m 0.7645,-1.7362 q 0.83595,0 1.22177,-0.48585 0.39297,-0.48585 0.42869,-1.65047 l 0,-0.23578 q 0,-1.28608 -0.40011,-1.84338 -0.39297,-0.5573 -1.28608,-0.5573 -0.72877,0 -1.13603,0.62161 -0.40012,0.61446 -0.40012,1.79336 0,1.1789 0.40726,1.77193 0.40726,0.58588 1.16462,0.58588 z"
+         style="font-weight:bold"
+         id="path4880"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 301.10959,664.71636 0,-1.08602 3.50814,0 0,1.08602 -3.50814,0 z"
+         style="font-weight:normal"
+         id="path4882"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 313.67743,668.09589 -1.21463,0 0,-9.36694 -3.30808,0 0,-1.07887 7.83078,0 0,1.07887 -3.30807,0 0,9.36694 z"
+         style="font-weight:normal"
+         id="path4884"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 323.73027,668.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18605,0 0,-11.11743 1.18605,0 0,3.36524 q 0,0.60731 -0.0572,1.00742 l 0.0715,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32866 1.47899,-0.32866 1.43612,0 2.1506,0.6859 0.72164,0.67877 0.72164,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path4886"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 328.53162,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path4888"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 336.11234,665.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56445,0.28579 1.20749,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.17891,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path4890"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.65102,668.09589 -0.23578,-1.1146 -0.0571,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32894,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26464,-0.44299 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.49299 0.69305,-0.17862 1.38611,-0.17862 1.40039,0 2.07201,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67932,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-weight:normal"
+         id="path4892"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 353.55297,660.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95026,0 -1.62903,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path4894"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 359.26173,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50786,-1.1146 1.47184,0 2.32922,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path4896"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.97162,668.09589 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25721 -1.45041,0.25721 -1.16461,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26465,-0.44299 -0.97884,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.49299 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60732 0.63589,-0.60731 0.63589,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.62161,0.38583 -0.62161,1.20749 0,0.64304 0.38583,0.97885 0.39296,0.33581 1.09316,0.33581 z"
+         style="font-weight:normal"
+         id="path4898"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 382.49687,668.09589 -1.43612,-4.59416 q -0.13576,-0.42155 -0.50729,-1.91483 l -0.0572,0 q -0.28579,1.25036 -0.50014,1.92912 l -1.47899,4.57987 -1.37182,0 -2.13631,-7.83079 1.2432,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28608,0 1.40039,4.49413 q 0.40012,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15005,-0.79308 0.1286,-0.53587 1.49327,-5.76592 l 1.22892,0 -2.16489,7.83079 -1.40754,0 z"
+         style="font-weight:normal"
+         id="path4900"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.66289,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path4902"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 392.37822,668.09589 -1.18604,0 0,-11.11743 1.18604,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path4904"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.09356,668.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path4906"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.06781,660.1365 q 1.5433,0 2.39354,1.05744 0.85738,1.05029 0.85738,2.97941 0,1.92912 -0.86453,3.00085 -0.85738,1.06458 -2.38639,1.06458 -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 -0.25007,1.00743 -0.85024,0 0,-11.11743 1.18604,0 0,2.70076 q 0,0.9074 -0.0571,1.62903 l 0.0571,0 q 0.82881,-1.17175 2.45784,-1.17175 z m -0.17147,0.99313 q -1.21463,0 -1.7505,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65047 0.55016,2.36495 0.55016,0.70735 1.76478,0.70735 1.09317,0 1.62904,-0.79309 0.53586,-0.80022 0.53586,-2.2935 0,-1.529 -0.53586,-2.27922 -0.53587,-0.75021 -1.65761,-0.75021 z"
+         style="font-weight:normal"
+         id="path4908"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 414.70597,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path4910"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.93057,667.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path4912"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 432.1466,660.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path4914"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.73333,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20005,-0.19291 0.50014,-0.19291 0.28579,0 0.49299,0.19291 0.20721,0.19291 0.20721,0.59302 0,0.40012 -0.20721,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path4916"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 448.24402,668.09589 0,-5.0943 q 0,-0.93598 -0.40012,-1.4004 -0.40011,-0.47156 -1.24321,-0.47156 -1.10745,0 -1.63617,0.6359 -0.52872,0.63589 -0.52872,1.95769 l 0,4.37267 -1.18605,0 0,-5.0943 q 0,-0.93598 -0.40012,-1.4004 -0.40011,-0.47156 -1.25035,-0.47156 -1.1146,0 -1.63617,0.67162 -0.51444,0.66447 -0.51444,2.18633 l 0,4.10831 -1.18604,0 0,-7.83079 0.96455,0 0.19291,1.07173 0.0572,0 q 0.33581,-0.57159 0.94313,-0.89311 0.61446,-0.32151 1.37181,-0.32151 1.83624,0 2.40068,1.32894 l 0.0572,0 q 0.3501,-0.61446 1.01457,-0.9717 0.66448,-0.35724 1.51472,-0.35724 1.32894,0 1.98627,0.6859 0.66448,0.67877 0.66448,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path4918"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.84785,668.09589 0,-5.0943 q 0,-0.93598 -0.40011,-1.4004 -0.40011,-0.47156 -1.24321,-0.47156 -1.10746,0 -1.63618,0.6359 -0.52872,0.63589 -0.52872,1.95769 l 0,4.37267 -1.18605,0 0,-5.0943 q 0,-0.93598 -0.40011,-1.4004 -0.40011,-0.47156 -1.25035,-0.47156 -1.1146,0 -1.63618,0.67162 -0.51443,0.66447 -0.51443,2.18633 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.33581,-0.57159 0.94312,-0.89311 0.61446,-0.32151 1.37182,-0.32151 1.83623,0 2.40068,1.32894 l 0.0572,0 q 0.3501,-0.61446 1.01457,-0.9717 0.66447,-0.35724 1.51471,-0.35724 1.32895,0 1.98628,0.6859 0.66447,0.67877 0.66447,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path4920"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.77837,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path4922"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 479.00271,667.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53614,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85739,-3.00799 0.85738,-1.07173 2.38638,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15718,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55015,-0.66448 0.55015,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55015,-0.71449 -1.76478,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55016,0.80737 -0.55016,2.28636 0,1.50042 0.55016,2.26492 0.55015,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path4924"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 493.20671,664.17335 q 0,1.91483 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.49299 -0.81452,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97941 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09316 0.97171,1.09317 0.97171,2.95798 z m -5.96598,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-weight:normal"
+         id="path4926"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 503.76683,661.18679 -1.99342,0 0,6.9091 -1.18604,0 0,-6.9091 -1.4004,0 0,-0.53586 1.4004,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.6216,0 1.45755,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32152,0.44298 -0.32152,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z m -4.95854,0 -1.99342,0 0,6.9091 -1.18605,0 0,-6.9091 -1.40039,0 0,-0.53586 1.40039,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.62161,0 1.45756,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32152,0.44298 -0.32152,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z"
+         style="font-weight:normal"
+         id="path4928"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8556">
+      <path
+         d="m 332.29654,748.41248 -2.515,-8.19518 -0.0643,0 q 0.13575,2.50071 0.13575,3.33666 l 0,4.85852 -1.97913,0 0,-10.44581 3.01514,0 2.47213,7.98797 0.0429,0 2.62217,-7.98797 3.01514,0 0,10.44581 -2.06487,0 0,-4.94426 q 0,-0.3501 0.007,-0.80737 0.0143,-0.45727 0.10003,-2.42926 l -0.0643,0 -2.69362,8.18089 -2.02914,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4847"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.57914,748.41248 -0.42154,-1.08603 -0.0572,0 q -0.55016,0.69306 -1.13604,0.96456 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65733 -0.65733,-0.65732 -0.65733,-1.87195 0,-1.27179 0.88597,-1.87196 0.89311,-0.60731 2.68647,-0.67162 l 1.38611,-0.0429 0,-0.3501 q 0,-1.21463 -1.24321,-1.21463 -0.95742,0 -2.25064,0.57874 l -0.72163,-1.47184 q 1.37896,-0.72164 3.05801,-0.72164 1.60759,0 2.46498,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64303,-3.70105 -0.8431,0.0286 q -0.95027,0.0286 -1.41468,0.34295 -0.46442,0.31438 -0.46442,0.95742 0,0.92169 1.05744,0.92169 0.75736,0 1.20748,-0.43584 0.45728,-0.43584 0.45728,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4849"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.4308,744.06839 0.95027,-1.21463 2.23634,-2.42926 2.45784,0 -3.17233,3.46527 3.36524,4.52271 -2.515,0 -2.30065,-3.23663 -0.93597,0.75021 0,2.48642 -2.17919,0 0,-11.11743 2.17919,0 0,4.95854 -0.11432,1.8148 0.0286,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4851"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 362.73371,741.8249 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92883 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4853"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 377.4593,746.04038 q 0,1.22892 -0.85739,1.87195 -0.85024,0.64304 -2.55072,0.64304 -0.87167,0 -1.48613,-0.12146 -0.61446,-0.11432 -1.15033,-0.34295 l 0,-1.80051 q 0.60732,0.28579 1.36467,0.4787 0.76451,0.19292 1.34324,0.19292 1.18605,0 1.18605,-0.68591 0,-0.25722 -0.15719,-0.4144 -0.15718,-0.16434 -0.54301,-0.36439 -0.38582,-0.2072 -1.02886,-0.47871 -0.92169,-0.38582 -1.35753,-0.71449 -0.42869,-0.32866 -0.62875,-0.75021 -0.19291,-0.42869 -0.19291,-1.0503 0,-1.06458 0.82166,-1.64332 0.82881,-0.58588 2.34352,-0.58588 1.44327,0 2.80794,0.62875 l -0.65733,1.57187 q -0.60017,-0.25721 -1.12175,-0.42154 -0.52157,-0.16434 -1.06458,-0.16434 -0.96456,0 -0.96456,0.52158 0,0.29294 0.30723,0.50729 0.31437,0.21434 1.36467,0.63589 0.93598,0.37868 1.37182,0.70734 0.43583,0.32867 0.64304,0.75736 0.2072,0.42869 0.2072,1.02172 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4855"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 384.83281,748.41248 -0.29294,-1.02172 -0.11432,0 q -0.3501,0.5573 -0.99314,0.86453 -0.64304,0.30008 -1.4647,0.30008 -1.40754,0 -2.12202,-0.75021 -0.71449,-0.75736 -0.71449,-2.17204 l 0,-5.20862 2.17919,0 0,4.66561 q 0,0.86453 0.30723,1.30037 0.30722,0.42869 0.97884,0.42869 0.91455,0 1.3218,-0.60732 0.40726,-0.61446 0.40726,-2.02914 l 0,-3.75821 2.17919,0 0,7.98798 -1.6719,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4857"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 393.26376,740.27446 q 0.44298,0 0.73592,0.0643 l -0.16433,2.04343 q -0.26436,-0.0715 -0.64304,-0.0715 -1.04315,0 -1.62903,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98798 1.65046,0 0.32152,1.34324 0.10718,0 q 0.37153,-0.67162 1.00028,-1.07887 0.63589,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4859"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.77246,741.8249 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40725,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92911,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00029,-3.10088 1.00742,-1.10031 2.77935,-1.10031 1.69334,0 2.63646,0.96456 0.94313,0.96456 0.94313,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92883 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34324,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22178,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4861"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.78187,740.4245 2.38639,0 1.50757,4.49413 q 0.19291,0.58588 0.26436,1.38611 l 0.0429,0 q 0.0786,-0.73592 0.30723,-1.38611 l 1.47899,-4.49413 2.33638,0 -3.37953,9.00969 q -0.46442,1.25036 -1.32895,1.87196 -0.85738,0.6216 -2.00771,0.6216 -0.56444,0 -1.10745,-0.12146 l 0,-1.72906 q 0.39297,0.0929 0.85738,0.0929 0.57874,0 1.00743,-0.35724 0.43584,-0.3501 0.67876,-1.06459 l 0.12861,-0.39296 -3.17232,-7.93082 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4863"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.97789,744.4042 q 0,1.18605 0.38582,1.79336 0.39297,0.60732 1.27179,0.60732 0.87167,0 1.25035,-0.60017 0.38583,-0.60732 0.38583,-1.80051 0,-1.18605 -0.38583,-1.77907 -0.38582,-0.59303 -1.26464,-0.59303 -0.87168,0 -1.2575,0.59303 -0.38582,0.58588 -0.38582,1.77907 z m 5.52299,0 q 0,1.95055 -1.02887,3.05086 -1.02886,1.10031 -2.86509,1.10031 -1.15033,0 -2.02915,-0.50014 -0.87881,-0.50728 -1.35038,-1.45041 -0.47156,-0.94312 -0.47156,-2.20062 0,-1.9577 1.02172,-3.04372 1.02172,-1.08602 2.87224,-1.08602 1.15032,0 2.02914,0.50014 0.87882,0.50015 1.35038,1.43612 0.47157,0.93598 0.47157,2.19348 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4865"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 430.96012,748.41248 -0.29294,-1.02172 -0.11431,0 q -0.3501,0.5573 -0.99314,0.86453 -0.64304,0.30008 -1.4647,0.30008 -1.40754,0 -2.12203,-0.75021 -0.71449,-0.75736 -0.71449,-2.17204 l 0,-5.20862 2.17919,0 0,4.66561 q 0,0.86453 0.30723,1.30037 0.30723,0.42869 0.97885,0.42869 0.91454,0 1.3218,-0.60732 0.40726,-0.61446 0.40726,-2.02914 l 0,-3.75821 2.17919,0 0,7.98798 -1.67191,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4867"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 434.62545,747.39076 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32866,0.32152 -0.91454,0.32152 -0.60017,0 -0.92884,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z m 0,-5.90167 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31438 0.32866,0.31437 0.32866,0.90025 0,0.57874 -0.3358,0.90026 -0.32867,0.31437 -0.9074,0.31437 -0.60017,0 -0.92884,-0.31437 -0.32866,-0.31438 -0.32866,-0.90026 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4869"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:150%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="176.30603"
-       y="788.41248"
-       id="text8562"
-       sodipodi:linespacing="150%"><tspan
-         sodipodi:role="line"
-         id="tspan8564"
-         x="176.30603"
-         y="788.41248"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
-   style="font-weight:bold;line-height:150%"
-   id="tspan8572">1.</tspan> Put your artwork in the &quot;Artwork&quot; layer.</tspan><tspan
-         sodipodi:role="line"
-         x="176.30603"
-         y="810.36151"
+       id="text8562">
+      <path
+         d="m 182.35059,788.41248 -2.20776,0 0,-6.04457 0.0214,-0.99314 0.0357,-1.08602 q -0.55016,0.55016 -0.7645,0.72163 l -1.20034,0.96456 -1.06459,-1.32894 3.36524,-2.67933 1.81479,0 0,10.44581 z"
+         style="font-weight:bold;line-height:150%"
+         id="path4668"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 185.4872,787.39076 q 0,-0.60017 0.32151,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59303,0 0.91455,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32867,0.32152 -0.91455,0.32152 -0.60017,0 -0.92883,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-weight:bold;line-height:150%"
+         id="path4670"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 200.68435,781.01038 q 0,1.58617 -1.08603,2.44355 -1.07887,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.10831 -1.21462,0 0,-10.44581 2.7079,0 q 3.9154,0 3.9154,3.04371 z m -5.40868,2.25064 1.09317,0 q 1.61474,0 2.33637,-0.52158 0.72164,-0.52157 0.72164,-1.6719 0,-1.036 -0.67877,-1.54329 -0.67876,-0.50729 -2.11488,-0.50729 l -1.35753,0 0,4.24406 z"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         id="tspan8568"><tspan
-   style="font-weight:bold;line-height:150%"
-   id="tspan8574">2.</tspan> Outline your text. (Select text, then Paths &gt; Object to Path) </tspan></text>
+         id="path4672"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.79951,780.58169 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47157 1.36467,0.47157 1.22892,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17147,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47184,0.30723 -1.42898,0 -2.14347,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4674"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.18816,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4676"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.38963,780.58169 1.27179,0 1.71477,4.46555 q 0.56444,1.529 0.70019,2.20777 l 0.0572,0 q 0.0929,-0.36439 0.38583,-1.24321 0.30008,-0.88597 1.9434,-5.43011 l 1.27179,0 -3.36524,8.91681 q -0.50014,1.3218 -1.17175,1.87195 -0.66448,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22177,0 1.74335,-1.37181 l 0.43583,-1.11461 -3.15803,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4678"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 234.7654,784.48994 q 0,1.91483 -0.96456,2.9937 -0.96455,1.07173 -2.66503,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75763,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4680"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 237.95202,780.58169 0,5.08001 q 0,0.95741 0.43583,1.42897 0.43584,0.47157 1.36468,0.47157 1.22891,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17148,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47185,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4682"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.38381,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4684"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 260.40122,788.41248 -0.23579,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40012,-1.35753 -0.39297,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.49299 0.69306,-0.17863 1.38611,-0.17863 1.40039,0 2.07201,0.62161 0.67877,0.6216 0.67877,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4686"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 267.30316,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4688"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.23313,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4690"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 281.27139,788.41248 -1.43612,-4.59416 q -0.13575,-0.42155 -0.50728,-1.91483 l -0.0572,0 q -0.2858,1.25036 -0.50014,1.92912 l -1.47899,4.57987 -1.37182,0 -2.13632,-7.83079 1.24321,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28608,0 1.40039,4.49413 q 0.40011,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15004,-0.79308 0.12861,-0.53587 1.49328,-5.76592 l 1.22892,0 -2.1649,7.83079 -1.40754,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4692"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 293.01042,784.48994 q 0,1.91483 -0.96455,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.25749,-1.41469 -0.44299,-0.92169 -0.44299,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4694"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 298.65488,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48586,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4696"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 302.22732,784.4042 q 0.30722,-0.43584 0.93597,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17232,3.33666 3.39381,4.49413 -1.43612,0 -2.76507,-3.70105 -0.8931,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4698"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 313.73057,788.41248 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50015,-0.19291 0.28579,0 0.49299,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50015,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4700"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 321.6185,788.41248 0,-5.06572 q 0,-0.95741 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66448 -0.57159,0.66447 -0.57159,2.19347 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67877 0.71448,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4702"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 331.56417,787.57653 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.3358,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4704"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 339.56644,788.41248 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18605,0 0,-11.11743 1.18605,0 0,3.36524 q 0,0.60731 -0.0571,1.00742 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65019,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67877 0.72163,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4706"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.48982,788.55537 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.11461 2.50786,-1.11461 1.47184,0 2.32923,0.97171 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4708"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 356.20684,777.96667 -0.28579,3.77249 -0.75021,0 -0.29294,-3.77249 1.32894,0 z m 2.63646,0 -0.29294,3.77249 -0.74307,0 -0.29294,-3.77249 1.32895,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4710"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 367.7887,788.41248 -1.30037,-3.32237 -4.1869,0 -1.28607,3.32237 -1.22892,0 4.12974,-10.48868 1.02171,0 4.10831,10.48868 -1.2575,0 z m -1.67905,-4.41554 -1.21463,-3.23663 q -0.23578,-0.61446 -0.48585,-1.50756 -0.15718,0.6859 -0.45012,1.50756 l -1.22892,3.23663 3.37952,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4712"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.87612,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4714"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 378.80609,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4716"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 387.84436,788.41248 -1.43612,-4.59416 q -0.13575,-0.42155 -0.50728,-1.91483 l -0.0572,0 q -0.2858,1.25036 -0.50015,1.92912 l -1.47898,4.57987 -1.37182,0 -2.13632,-7.83079 1.24321,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28607,0 1.4004,4.49413 q 0.40011,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15004,-0.79308 0.12861,-0.53587 1.49328,-5.76592 l 1.22892,0 -2.1649,7.83079 -1.40754,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4718"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 399.58338,784.48994 q 0,1.91483 -0.96455,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.25749,-1.41469 -0.44299,-0.92169 -0.44299,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4720"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 405.22784,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48586,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4722"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 408.80028,784.4042 q 0.30722,-0.43584 0.93597,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17232,3.33666 3.39381,4.49413 -1.43612,0 -2.76507,-3.70105 -0.8931,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4724"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 416.33811,777.96667 -0.28579,3.77249 -0.75021,0 -0.29294,-3.77249 1.32894,0 z m 2.63646,0 -0.29294,3.77249 -0.74306,0 -0.29294,-3.77249 1.32894,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4726"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.16233,788.41248 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4728"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 433.50726,788.41248 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40012,-1.35753 -0.39296,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26464,-0.49299 0.69306,-0.17863 1.38611,-0.17863 1.40039,0 2.07201,0.62161 0.67877,0.6216 0.67877,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4730"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.59357,780.58169 1.27179,0 1.71477,4.46555 q 0.56445,1.529 0.7002,2.20777 l 0.0572,0 q 0.0929,-0.36439 0.38582,-1.24321 0.30009,-0.88597 1.94341,-5.43011 l 1.27179,0 -3.36524,8.91681 q -0.50014,1.3218 -1.17176,1.87195 -0.66447,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22178,0 1.74335,-1.37181 l 0.43584,-1.11461 -3.15804,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4732"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 447.51836,788.55537 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.11461 2.50786,-1.11461 1.47184,0 2.32922,0.97171 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4734"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 455.98503,780.43879 q 0.52157,0 0.93597,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35039,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4736"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 458.21423,787.65512 q 0,-0.47871 0.21434,-0.72163 0.22149,-0.25007 0.62875,-0.25007 0.4144,0 0.64304,0.25007 0.23578,0.24292 0.23578,0.72163 0,0.46442 -0.23578,0.71449 -0.23578,0.25007 -0.64304,0.25007 -0.36439,0 -0.60731,-0.22149 -0.23578,-0.22864 -0.23578,-0.74307 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4738"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 184.19397,810.36153 -7.30206,0 0,-1.53615 2.62217,-2.65074 q 1.16461,-1.1932 1.52186,-1.65047 0.35724,-0.46442 0.51443,-0.85739 0.15719,-0.39296 0.15719,-0.81451 0,-0.62875 -0.3501,-0.93598 -0.34296,-0.30723 -0.92169,-0.30723 -0.60732,0 -1.17891,0.27865 -0.57159,0.27865 -1.19319,0.79308 l -1.20034,-1.42183 q 0.77165,-0.65733 1.27893,-0.92883 0.50729,-0.27151 1.10746,-0.41441 0.60017,-0.15004 1.34324,-0.15004 0.97884,0 1.72906,0.35725 0.75021,0.35724 1.16461,1.00028 0.4144,0.64304 0.4144,1.47184 0,0.72164 -0.25721,1.35753 -0.25007,0.62875 -0.78594,1.29322 -0.52872,0.66448 -1.87196,1.89339 l -1.34323,1.26465 0,0.10003 4.55128,0 0,1.85766 z"
+         style="font-weight:bold;line-height:150%"
+         id="path4740"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 185.4872,809.33982 q 0,-0.60017 0.32151,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59303,0 0.91455,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.8931 -0.32867,0.32152 -0.91455,0.32152 -0.60017,0 -0.92883,-0.31437 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-weight:bold;line-height:150%"
+         id="path4742"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.12789,805.12434 q 0,2.50785 -1.27179,3.94397 -1.26464,1.43612 -3.52242,1.43612 -2.30779,0 -3.56529,-1.40754 -1.25035,-1.41469 -1.25035,-3.98684 0,-2.55072 1.25749,-3.95112 1.2575,-1.40754 3.57244,-1.40754 2.25064,0 3.51528,1.42898 1.26464,1.42897 1.26464,3.94397 z m -8.32378,0 q 0,2.12203 0.90026,3.22234 0.9074,1.09316 2.62931,1.09316 1.73621,0 2.62217,-1.09316 0.88596,-1.09317 0.88596,-3.22234 0,-2.10774 -0.88596,-3.19376 -0.87882,-1.09317 -2.60788,-1.09317 -1.7362,0 -2.6436,1.10031 -0.90026,1.09317 -0.90026,3.18662 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4744"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 206.40025,802.53075 0,5.08001 q 0,0.95741 0.43583,1.42897 0.43584,0.47156 1.36467,0.47156 1.22892,0 1.79337,-0.67162 0.57159,-0.67161 0.57159,-2.19347 l 0,-4.11545 1.18605,0 0,7.83078 -0.97885,0 -0.17148,-1.05029 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47185,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70734,-0.67877 -0.70734,-2.17205 l 0,-5.12287 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4746"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.78889,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.3358,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4748"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.61855,810.36153 -1.18605,0 0,-11.11742 1.18605,0 0,11.11742 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4750"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 224.33388,810.36153 -1.18605,0 0,-7.83078 1.18605,0 0,7.83078 z m -1.28608,-9.95281 q 0,-0.40726 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40011 -0.2072,0.60017 -0.2072,0.19291 -0.493,0.19291 -0.30008,0 -0.50014,-0.19291 -0.20006,-0.20006 -0.20006,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4752"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 232.22183,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66447 -0.57159,0.66448 -0.57159,2.19348 l 0,4.1083 -1.18605,0 0,-7.83078 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67876 0.71448,2.17919 l 0,5.10858 -1.18604,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4754"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.14521,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39439,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4756"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 246.59731,802.53075 1.27179,0 1.71477,4.46555 q 0.56445,1.529 0.7002,2.20776 l 0.0572,0 q 0.0929,-0.36439 0.38582,-1.24321 0.30009,-0.88596 1.94341,-5.4301 l 1.27178,0 -3.36523,8.9168 q -0.50014,1.32181 -1.17176,1.87196 -0.66447,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22177,0 1.74335,-1.37182 l 0.43584,-1.1146 -3.15804,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4758"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.97309,806.439 q 0,1.91482 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.493 -0.81452,-0.49299 -1.2575,-1.41468 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97942 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09317 0.97171,1.09316 0.97171,2.95798 z m -5.96598,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78593 1.76479,0.78593 1.16461,0 1.76478,-0.77879 0.60732,-0.78594 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.7645 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4760"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 265.1597,802.53075 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47156 1.36467,0.47156 1.22892,0 1.79337,-0.67162 0.57159,-0.67161 0.57159,-2.19347 l 0,-4.11545 1.18605,0 0,7.83078 -0.97885,0 -0.17148,-1.05029 -0.0643,0 q -0.36439,0.57873 -1.01458,0.88596 -0.64303,0.30723 -1.47184,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70735,-0.67877 -0.70735,-2.17205 l 0,-5.12287 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4762"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 276.5915,802.38785 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77164 -0.67162,0.77165 -0.67162,1.92198 l 0,4.20118 -1.18605,0 0,-7.83078 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.17891 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4764"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 285.32254,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.6859,0 0,1.8148 2.27208,0 0,0.92169 -2.27208,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4766"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 291.27422,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35039,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4768"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 298.05471,806.35326 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05773,-3.00085 1.33609,0 -2.7222,3.82251 2.8651,4.00827 -1.34324,0 -2.19348,-3.17232 -2.21491,3.17232 -1.34323,0 2.86509,-4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4770"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 306.35705,809.52558 q 0.31438,0 0.60732,-0.0429 0.29293,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4772"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 308.82919,809.60418 q 0,-0.47871 0.21434,-0.72164 0.22149,-0.25007 0.62875,-0.25007 0.4144,0 0.64304,0.25007 0.23578,0.24293 0.23578,0.72164 0,0.46441 -0.23578,0.71448 -0.23578,0.25007 -0.64304,0.25007 -0.36439,0 -0.60731,-0.22149 -0.23578,-0.22863 -0.23578,-0.74306 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4774"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 316.01693,806.35326 q 0,-1.89339 0.55015,-3.54386 0.5573,-1.65047 1.60045,-2.89368 l 1.15747,0 q -1.02886,1.37897 -1.55044,3.02943 -0.51443,1.65047 -0.51443,3.39382 0,1.71477 0.52872,3.35094 0.52873,1.63618 1.52186,2.98656 l -1.14318,0 q -1.05029,-1.21463 -1.60045,-2.83651 -0.55015,-1.62189 -0.55015,-3.4867 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4776"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 327.10577,807.58218 q 0,1.37896 -1.00028,2.1506 -1.00028,0.77165 -2.71505,0.77165 -1.85767,0 -2.85795,-0.47871 l 0,-1.17176 q 0.64304,0.27151 1.40039,0.4287 0.75736,0.15718 1.50043,0.15718 1.21463,0 1.82909,-0.45727 0.61445,-0.46442 0.61445,-1.28608 0,-0.54301 -0.22149,-0.88596 -0.21434,-0.3501 -0.72877,-0.64304 -0.50729,-0.29294 -1.55044,-0.66447 -1.45756,-0.52158 -2.08631,-1.23607 -0.6216,-0.71448 -0.6216,-1.86481 0,-1.20748 0.9074,-1.92197 0.9074,-0.71449 2.40068,-0.71449 1.55758,0 2.86509,0.57159 l -0.37868,1.05744 q -1.29322,-0.54301 -2.51499,-0.54301 -0.96456,0 -1.50757,0.41441 -0.54301,0.4144 -0.54301,1.15032 0,0.54301 0.20006,0.89311 0.20005,0.34295 0.67161,0.63589 0.47871,0.2858 1.45756,0.6359 1.64332,0.58588 2.25778,1.2575 0.6216,0.67161 0.6216,1.74335 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4778"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.37154,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4780"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 338.45183,810.36153 -1.18605,0 0,-11.11742 1.18605,0 0,11.11742 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4782"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 344.28919,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65732,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4784"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.31289,810.50443 q -1.70048,0 -2.63646,-1.04315 -0.92884,-1.0503 -0.92884,-2.96512 0,-1.96485 0.94313,-3.03658 0.95027,-1.07173 2.70076,-1.07173 0.56445,0 1.12889,0.12146 0.56445,0.12147 0.88597,0.2858 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85739,-0.25722 -0.46441,-0.10717 -0.82166,-0.10717 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57874,2.21491 0.58588,0.77164 1.72906,0.77164 0.97885,0 2.00771,-0.42154 l 0,1.05029 q -0.78594,0.40726 -1.97913,0.40726 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4786"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 358.68612,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4788"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 367.66009,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4790"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.61176,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.55731,0.12146 -1.35039,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4792"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 380.39225,806.35326 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05773,-3.00085 1.33609,0 -2.7222,3.82251 2.8651,4.00827 -1.34324,0 -2.19348,-3.17232 -2.21491,3.17232 -1.34324,0 2.8651,-4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4794"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.69461,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4796"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 392.58141,808.66105 0.10717,0.16433 q -0.18576,0.71449 -0.53586,1.65762 -0.3501,0.95026 -0.72878,1.76478 l -0.89311,0 q 0.19291,-0.74307 0.42155,-1.83623 0.23578,-1.09317 0.32866,-1.7505 l 1.30037,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4798"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 401.26957,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27208,0 -2.27208,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4800"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 409.27184,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67876 0.72163,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4802"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 416.19523,810.50443 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93655 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12175 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4804"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.44812,810.36153 0,-5.06571 q 0,-0.95742 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66447 -0.57159,0.66448 -0.57159,2.19348 l 0,4.1083 -1.18605,0 0,-7.83078 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67876 0.71448,2.17919 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4806"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 440.66641,802.95944 q 0,1.58616 -1.08602,2.44355 -1.07887,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.1083 -1.21463,0 0,-10.44581 2.70791,0 q 3.91539,0 3.91539,3.04372 z m -5.40867,2.25064 1.09317,0 q 1.61474,0 2.33637,-0.52158 0.72164,-0.52157 0.72164,-1.6719 0,-1.03601 -0.67877,-1.54329 -0.67876,-0.50729 -2.11488,-0.50729 l -1.35753,0 0,4.24406 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4808"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 447.48263,810.36153 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25722 -1.45041,0.25722 -1.16461,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35753 -0.39297,-0.44298 -1.26465,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.493 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.62161 0.67876,0.6216 0.67876,1.99342 l 0,5.34436 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60731 0.63589,-0.60732 0.63589,-1.70048 l 0,-0.70735 -1.18605,0.05 q -1.41469,0.05 -2.04343,0.44298 -0.62161,0.38582 -0.62161,1.20749 0,0.64303 0.38582,0.97884 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4810"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 453.34144,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4812"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.34369,810.36153 0,-5.06571 q 0,-0.95742 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23607,0 -1.80766,0.67162 -0.56444,0.67162 -0.56444,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0715,0 q 0.3501,-0.56444 0.99313,-0.88596 0.65019,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67876 0.72163,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4814"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 470.01043,808.22521 q 0,1.09317 -0.81451,1.6862 -0.81452,0.59302 -2.28636,0.59302 -1.55759,0 -2.42926,-0.493 l 0,-1.10031 q 0.56444,0.2858 1.20748,0.45013 0.65019,0.16433 1.25036,0.16433 0.92883,0 1.42897,-0.29294 0.50014,-0.30008 0.50014,-0.9074 0,-0.45727 -0.40011,-0.77879 -0.39297,-0.32866 -1.54329,-0.77164 -1.09317,-0.40726 -1.55759,-0.70735 -0.45727,-0.30723 -0.6859,-0.69305 -0.2215,-0.38582 -0.2215,-0.92169 0,-0.95741 0.7788,-1.50757 0.77879,-0.5573 2.13631,-0.5573 1.26465,0 2.47213,0.51443 l -0.42155,0.96456 q -1.1789,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27178,0.26436 -0.4287,0.26436 -0.4287,0.72878 0,0.31437 0.15719,0.53586 0.16433,0.22149 0.52158,0.42155 0.35724,0.20006 1.37181,0.57874 1.39325,0.50728 1.87911,1.02171 0.49299,0.51443 0.49299,1.29322 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4816"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 475.21905,807.5536 5.59444,-2.32923 -5.59444,-2.66504 0,-1.06459 6.86622,3.4224 0,0.7002 -6.86622,3.01513 0,-1.07887 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4818"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 497.15382,805.12434 q 0,2.50785 -1.27179,3.94397 -1.26465,1.43612 -3.52243,1.43612 -2.30779,0 -3.56529,-1.40754 -1.25035,-1.41469 -1.25035,-3.98684 0,-2.55072 1.2575,-3.95112 1.25749,-1.40754 3.57243,-1.40754 2.25064,0 3.51528,1.42898 1.26465,1.42897 1.26465,3.94397 z m -8.32378,0 q 0,2.12203 0.90025,3.22234 0.9074,1.09316 2.62931,1.09316 1.73621,0 2.62217,-1.09316 0.88597,-1.09317 0.88597,-3.22234 0,-2.10774 -0.88597,-3.19376 -0.87882,-1.09317 -2.60788,-1.09317 -1.7362,0 -2.6436,1.10031 -0.90025,1.09317 -0.90025,3.18662 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4820"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 502.95546,802.40214 q 1.54329,0 2.39353,1.05744 0.85739,1.0503 0.85739,2.97942 0,1.92911 -0.86453,3.00084 -0.85739,1.06459 -2.38639,1.06459 -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 -0.25007,1.00742 -0.85024,0 0,-11.11742 1.18604,0 0,2.70076 q 0,0.9074 -0.0571,1.62903 l 0.0571,0 q 0.82881,-1.17176 2.45784,-1.17176 z m -0.17148,0.99314 q -1.21462,0 -1.75049,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65046 0.55016,2.36495 0.55016,0.70734 1.76478,0.70734 1.09317,0 1.62904,-0.79308 0.53586,-0.80022 0.53586,-2.2935 0,-1.52901 -0.53586,-2.27922 -0.53587,-0.75021 -1.65762,-0.75021 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4822"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 507.33524,813.87681 q -0.67876,0 -1.10031,-0.17862 l 0,-0.96456 q 0.493,0.1429 0.97171,0.1429 0.5573,0 0.81451,-0.30723 0.26436,-0.30009 0.26436,-0.92169 l 0,-9.11686 1.18605,0 0,9.03112 q 0,2.31494 -2.13632,2.31494 z m 0.85024,-13.46809 q 0,-0.40726 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40011 -0.2072,0.60017 -0.2072,0.19291 -0.493,0.19291 -0.30008,0 -0.50014,-0.19291 -0.20006,-0.20006 -0.20006,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4824"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 515.30892,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65732,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4826"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 523.33263,810.50443 q -1.70048,0 -2.63646,-1.04315 -0.92883,-1.0503 -0.92883,-2.96512 0,-1.96485 0.94312,-3.03658 0.95027,-1.07173 2.70077,-1.07173 0.56444,0 1.12889,0.12146 0.56444,0.12147 0.88596,0.2858 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85738,-0.25722 -0.46442,-0.10717 -0.82166,-0.10717 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57873,2.21491 0.58588,0.77164 1.72906,0.77164 0.97885,0 2.00771,-0.42154 l 0,1.05029 q -0.78593,0.40726 -1.97913,0.40726 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4828"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 529.70585,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4830"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 538.67982,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4832"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 548.08247,806.439 q 0,1.91482 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.493 -0.81452,-0.49299 -1.2575,-1.41468 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97942 0.95742,-1.07173 2.6579,-1.07173 1.64332,0 2.60788,1.09317 0.9717,1.09316 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78593 1.76478,0.78593 1.16462,0 1.76479,-0.77879 0.60731,-0.78594 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75764,0.7645 -0.59302,0.7645 -0.59302,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4834"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 560.75748,802.95944 q 0,1.58616 -1.08602,2.44355 -1.07888,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.1083 -1.21463,0 0,-10.44581 2.70791,0 q 3.91539,0 3.91539,3.04372 z m -5.40867,2.25064 1.09316,0 q 1.61475,0 2.33638,-0.52158 0.72163,-0.52157 0.72163,-1.6719 0,-1.03601 -0.67876,-1.54329 -0.67877,-0.50729 -2.11489,-0.50729 l -1.35752,0 0,4.24406 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4836"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 567.57369,810.36153 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25722 -1.45041,0.25722 -1.16461,0 -1.82908,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32894,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35753 -0.39297,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.493 0.69305,-0.17862 1.38611,-0.17862 1.40039,0 2.07201,0.62161 0.67876,0.6216 0.67876,1.99342 l 0,5.34436 -0.87882,0 z m -2.67932,-0.83595 q 1.10745,0 1.7362,-0.60731 0.63589,-0.60732 0.63589,-1.70048 l 0,-0.70735 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.6216,0.38582 -0.6216,1.20749 0,0.64303 0.38582,0.97884 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4838"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 573.43251,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4840"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 581.43476,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0715,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32867 1.47899,-0.32867 1.43612,0 2.1506,0.68591 0.72164,0.67876 0.72164,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4842"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 587.53649,806.35326 q 0,1.8791 -0.5573,3.50099 -0.55016,1.62188 -1.59331,2.82222 l -1.14318,0 q 0.99314,-1.34323 1.52186,-2.97941 0.52872,-1.64332 0.52872,-3.35809 0,-1.74335 -0.52158,-3.39382 -0.51443,-1.65046 -1.54329,-3.02943 l 1.15747,0 q 1.0503,1.25036 1.60045,2.90797 0.55016,1.65047 0.55016,3.52957 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path4844"
+         inkscape:connector-curvature="0" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(178.67433,582.63783)"
-     style="display:inline"
-     sodipodi:insensitive="true">
+     style="display:inline">
     <path
        sodipodi:type="star"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:#f0a028;stroke-width:25.03716469;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
@@ -226,7 +1723,8 @@
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Trim Lines"
-     style="display:inline">
+     style="display:inline"
+     sodipodi:insensitive="true">
     <path
        transform="matrix(0.86033594,0,0,0.86346354,277.62095,265.70622)"
        inkscape:transform-center-y="-1.5566024"
@@ -310,19 +1808,41 @@
          style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
          d="m 204.639,587.124 -3.549,0 1.773,3.076 1.776,3.073 1.775,-3.073 1.774,-3.076 -3.549,0" />
     </g>
-    <text
-       xml:space="preserve"
+    <g
+       transform="matrix(0,-1,1,0,0,0)"
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="-400.8819"
-       y="516.31042"
-       id="text8536-9"
-       sodipodi:linespacing="521%"
-       transform="matrix(0,-1,1,0,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan8538-3"
-         x="-400.8819"
-         y="516.31042"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">5.08 cm</tspan></text>
+       id="text8536-9">
+      <path
+         d="m -396.49494,509.63711 q 1.51471,0 2.40782,0.85024 0.90025,0.85024 0.90025,2.32923 0,1.7505 -1.07887,2.69362 -1.07888,0.94312 -3.08659,0.94312 -1.74335,0 -2.81508,-0.56444 l 0,-1.90768 q 0.56445,0.30008 1.31466,0.49299 0.75021,0.18577 1.42183,0.18577 2.022,0 2.022,-1.65761 0,-1.57902 -2.09345,-1.57902 -0.37868,0 -0.83595,0.0786 -0.45727,0.0715 -0.74307,0.15719 l -0.87882,-0.47156 0.39297,-5.32293 5.66589,0 0,1.87195 -3.72963,0 -0.19291,2.05058 0.25007,-0.05 q 0.43584,-0.10003 1.07888,-0.10003 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5051"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -391.70073,515.28871 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32866,0.32152 -0.91454,0.32152 -0.60017,0 -0.92884,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5053"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -380.53329,511.08752 q 0,2.73649 -0.90026,4.05115 -0.89311,1.31465 -2.75792,1.31465 -1.80765,0 -2.72934,-1.35752 -0.91454,-1.35753 -0.91454,-4.00828 0,-2.76507 0.89311,-4.07258 0.8931,-1.31466 2.75077,-1.31466 1.80766,0 2.72934,1.37182 0.92884,1.37182 0.92884,4.01542 z m -5.10859,0 q 0,1.92197 0.32867,2.75792 0.33581,0.82881 1.12174,0.82881 0.77165,0 1.1146,-0.8431 0.34296,-0.84309 0.34296,-2.74363 0,-1.92197 -0.3501,-2.75792 -0.34296,-0.8431 -1.10746,-0.8431 -0.77879,0 -1.1146,0.8431 -0.33581,0.83595 -0.33581,2.75792 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5055"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -375.83196,505.72886 q 1.50042,0 2.41496,0.68591 0.92169,0.67877 0.92169,1.83624 0,0.80022 -0.44298,1.42897 -0.44298,0.6216 -1.42897,1.1146 1.17176,0.62875 1.67904,1.31466 0.51443,0.67876 0.51443,1.49328 0,1.28607 -1.00742,2.07201 -1.00743,0.77879 -2.65075,0.77879 -1.71477,0 -2.69362,-0.72877 -0.97885,-0.72878 -0.97885,-2.06487 0,-0.89311 0.47156,-1.58617 0.47871,-0.69305 1.52901,-1.22177 -0.89311,-0.56445 -1.28608,-1.20748 -0.39297,-0.64304 -0.39297,-1.40754 0,-1.12175 0.92883,-1.8148 0.92884,-0.69306 2.42212,-0.69306 z m -1.62903,7.80221 q 0,0.61446 0.42869,0.95741 0.42869,0.34296 1.17176,0.34296 0.82166,0 1.22892,-0.3501 0.40725,-0.35725 0.40725,-0.93598 0,-0.47871 -0.40725,-0.89311 -0.40012,-0.42155 -1.30752,-0.89311 -1.52185,0.7002 -1.52185,1.77193 z m 1.61474,-6.18746 q -0.56445,0 -0.91455,0.29294 -0.34295,0.28579 -0.34295,0.77164 0,0.4287 0.2715,0.77165 0.27865,0.33581 1.00029,0.69305 0.70019,-0.32866 0.97885,-0.67162 0.27865,-0.34295 0.27865,-0.79308 0,-0.49299 -0.35725,-0.77879 -0.35724,-0.28579 -0.91454,-0.28579 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5057"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -363.48562,516.45332 q -3.72962,0 -3.72962,-4.09401 0,-2.03629 1.01457,-3.10802 1.01457,-1.07888 2.90797,-1.07888 1.3861,0 2.48641,0.54301 l -0.64304,1.68619 q -0.51443,-0.2072 -0.95741,-0.33581 -0.44298,-0.13575 -0.88596,-0.13575 -1.70049,0 -1.70049,2.41497 0,2.34352 1.70049,2.34352 0.62874,0 1.16461,-0.16433 0.53587,-0.17148 1.07173,-0.52872 l 0,1.86481 q -0.52872,0.33581 -1.07173,0.46441 -0.53587,0.12861 -1.35753,0.12861 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5059"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -352.06096,516.31042 -2.17919,0 0,-4.6656 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.83595,0 -1.21463,0.61446 -0.37868,0.61446 -0.37868,2.022 l 0,3.7582 -2.17918,0 0,-7.98797 1.66475,0 0.29294,1.02172 0.12147,0 q 0.32152,-0.55015 0.92883,-0.85738 0.60731,-0.31438 1.39325,-0.31438 1.79336,0 2.42926,1.17176 l 0.19291,0 q 0.32152,-0.5573 0.94312,-0.86453 0.62875,-0.30723 1.41469,-0.30723 1.35752,0 2.05058,0.7002 0.7002,0.69305 0.7002,2.2292 l 0,5.20861 -2.18634,0 0,-4.6656 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.80022,0 -1.20033,0.57159 -0.39297,0.57159 -0.39297,1.8148 l 0,4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5061"
+         inkscape:connector-curvature="0" />
+    </g>
   </g>
   <g
      inkscape:groupmode="layer"

--- a/assets/square-sticker_template.svg
+++ b/assets/square-sticker_template.svg
@@ -25,11 +25,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.4121212"
-     inkscape:cx="316.35347"
-     inkscape:cy="891.11087"
+     inkscape:zoom="1.2060606"
+     inkscape:cx="218.0997"
+     inkscape:cy="526.28675"
      inkscape:document-units="px"
-     inkscape:current-layer="layer4"
+     inkscape:current-layer="layer3"
      showgrid="false"
      units="in"
      fit-margin-top="1"
@@ -70,31 +70,625 @@
      inkscape:label="Template Text"
      style="display:inline"
      sodipodi:insensitive="true">
-    <text
-       sodipodi:linespacing="521%"
-       id="text8212"
-       y="101.80281"
-       x="73.142006"
+    <g
        style="font-style:normal;font-weight:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+       id="text8212">
+      <path
+         d="m 83.336059,86.295895 q 3.519771,0 5.595108,1.975721 2.091939,1.97572 2.091939,5.412478 0,4.06766 -2.507006,6.259215 -2.507007,2.191551 -7.172364,2.191551 -4.051057,0 -6.541461,-1.31161 l 0,-4.432917 q 1.311613,0.697313 3.054896,1.145586 1.743283,0.43167 3.303936,0.43167 4.698562,0 4.698562,-3.851825 0,-3.669195 -4.864589,-3.669195 -0.879943,0 -1.942515,0.182629 -1.062573,0.166027 -1.72668,0.365259 l -2.042132,-1.095777 0.913148,-12.369007 13.165936,0 0,4.349906 -8.666606,0 -0.448272,4.764973 0.581094,-0.116219 q 1.012764,-0.232438 2.507006,-0.232438 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="101.80281"
-         x="73.142006"
-         id="tspan8214"
-         sodipodi:role="line">5.08 cm / 2&quot; Square Sticker Template</tspan></text>
-    <text
+         id="path5363"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 94.476466,99.428626 q 0,-1.394627 0.747121,-2.108542 0.747121,-0.713916 2.174953,-0.713916 1.378023,0 2.125145,0.730518 0.763725,0.730519 0.763725,2.09194 0,1.311614 -0.763725,2.075334 -0.763724,0.74712 -2.125145,0.74712 -1.394626,0 -2.15835,-0.73052 -0.763724,-0.74712 -0.763724,-2.091934 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5365"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 120.42647,89.666242 q 0,6.358831 -2.09193,9.413727 -2.07534,3.054891 -6.40864,3.054891 -4.20049,0 -6.34223,-3.154507 -2.12515,-3.154512 -2.12515,-9.314111 0,-6.425242 2.07534,-9.463535 2.07534,-3.054896 6.39204,-3.054896 4.20048,0 6.34222,3.187717 2.15835,3.187718 2.15835,9.330714 z m -11.87092,0 q 0,4.466124 0.76372,6.40864 0.78033,1.925912 2.60663,1.925912 1.79309,0 2.59002,-1.959118 0.79693,-1.959118 0.79693,-6.375434 0,-4.466124 -0.81354,-6.40864 -0.79693,-1.959117 -2.57341,-1.959117 -1.8097,0 -2.59002,1.959117 -0.78033,1.942516 -0.78033,6.40864 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5367"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 131.35105,77.214222 q 3.48656,0 5.61171,1.593859 2.14174,1.577256 2.14174,4.266892 0,1.859501 -1.02936,3.320538 -1.02937,1.444435 -3.32054,2.590021 2.72284,1.461037 3.90163,3.054895 1.1954,1.577256 1.1954,3.469963 0,2.988485 -2.34098,4.81478 -2.34098,1.80969 -6.1596,1.80969 -3.98465,0 -6.25922,-1.69347 -2.27457,-1.693475 -2.27457,-4.798178 0,-2.075337 1.09578,-3.685798 1.11238,-1.610462 3.55298,-2.839061 -2.07534,-1.311613 -2.98849,-2.805855 -0.91315,-1.494242 -0.91315,-3.270731 0,-2.606622 2.15835,-4.217084 2.15835,-1.610461 5.62832,-1.610461 z m -3.78542,18.130141 q 0,1.427832 0.99616,2.224761 0.99617,0.796929 2.72285,0.796929 1.90931,0 2.85566,-0.813532 0.94635,-0.830134 0.94635,-2.174953 0,-1.11238 -0.94635,-2.075336 -0.92975,-0.979559 -3.03829,-2.075337 -3.53638,1.627064 -3.53638,4.117468 z m 3.75221,-14.377932 q -1.31161,0 -2.12514,0.68071 -0.79693,0.664108 -0.79693,1.793091 0,0.996162 0.6309,1.793091 0.6475,0.780327 2.32438,1.610461 1.62706,-0.763724 2.27457,-1.560653 0.6475,-0.796929 0.6475,-1.842899 0,-1.145586 -0.83013,-1.809693 -0.83014,-0.664108 -2.12515,-0.664108 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5369"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 160.0405,102.13486 q -8.66661,0 -8.66661,-9.513339 0,-4.731767 2.35758,-7.222171 2.35759,-2.507007 6.7573,-2.507007 3.22092,0 5.77774,1.261805 l -1.49425,3.918235 q -1.19539,-0.481478 -2.22476,-0.780326 -1.02936,-0.315451 -2.05873,-0.315451 -3.95144,0 -3.95144,5.61171 0,5.445683 3.95144,5.445683 1.46104,0 2.70624,-0.381862 1.2452,-0.398464 2.4904,-1.228599 l 0,4.333302 q -1.2286,0.78033 -2.4904,1.07918 -1.2452,0.29884 -3.15451,0.29884 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5371"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 186.5882,101.80281 -5.06382,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10854,-1.012765 -1.94252,0 -2.82246,1.427832 -0.87994,1.427832 -0.87994,4.698562 l 0,8.733016 -5.06382,0 0,-18.56181 3.86843,0 0.68071,2.374185 0.28224,0 q 0.74712,-1.278407 2.15835,-1.992323 1.41123,-0.730519 3.23753,-0.730519 4.16727,0 5.64491,2.722842 l 0.44828,0 q 0.74712,-1.29501 2.19155,-2.008926 1.46104,-0.713916 3.28733,-0.713916 3.15452,0 4.76498,1.627064 1.62706,1.610461 1.62706,5.18004 l 0,12.103363 -5.08042,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10855,-1.012765 -1.8595,0 -2.78925,1.328216 -0.91315,1.328215 -0.91315,4.217084 l 0,9.31411 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5373"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 223.42959,77.529673 -9.04847,24.273137 -4.59895,0 9.04847,-24.273137 4.59895,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5375"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 250.79082,101.80281 -16.96795,0 0,-3.569578 6.09319,-6.1596 q 2.70624,-2.772649 3.53637,-3.835222 0.83014,-1.079175 1.1954,-1.992323 0.36525,-0.913148 0.36525,-1.892707 0,-1.461037 -0.81353,-2.174953 -0.79693,-0.713915 -2.14174,-0.713915 -1.41123,0 -2.73945,0.647505 -1.32821,0.647505 -2.77265,1.842899 l -2.78925,-3.303936 q 1.79309,-1.527448 2.97188,-2.15835 1.17879,-0.630903 2.57342,-0.962957 1.39462,-0.348656 3.1213,-0.348656 2.27457,0 4.01786,0.830134 1.74328,0.830135 2.70624,2.324377 0.96295,1.494243 0.96295,3.420155 0,1.676872 -0.5977,3.154512 -0.58109,1.461037 -1.82629,3.005087 -1.2286,1.544051 -4.34991,4.399714 l -3.1213,2.938677 0,0.232437 10.57591,0 0,4.3167 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5377"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 258.6937,77.529673 -0.68071,8.766222 -3.27074,0 -0.68071,-8.766222 4.63216,0 z m 7.00633,0 -0.68071,8.766222 -3.27073,0 -0.68071,-8.766222 4.63215,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5379"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 294.14046,95.062117 q 0,3.287333 -2.37419,5.180043 -2.35758,1.8927 -6.57466,1.8927 -3.88503,0 -6.87352,-1.46103 l 0,-4.781578 q 2.4572,1.095778 4.15068,1.54405 1.71007,0.448273 3.1213,0.448273 1.69348,0 2.59002,-0.647505 0.91315,-0.647505 0.91315,-1.925912 0,-0.713916 -0.39846,-1.261805 -0.39847,-0.564492 -1.1788,-1.079175 -0.76372,-0.514684 -3.13791,-1.643667 -2.22476,-1.045969 -3.33714,-2.008926 -1.11238,-0.962956 -1.77648,-2.241363 -0.66411,-1.278408 -0.66411,-2.988485 0,-3.220922 2.17495,-5.063821 2.19156,-1.842899 6.04338,-1.842899 1.89271,0 3.60279,0.448272 1.72668,0.448273 3.60278,1.261805 l -1.66027,4.001249 q -1.94251,-0.796929 -3.22092,-1.11238 -1.26181,-0.315451 -2.49041,-0.315451 -1.46103,0 -2.24136,0.68071 -0.78033,0.68071 -0.78033,1.776488 0,0.680711 0.31545,1.195394 0.31546,0.498081 0.99617,0.979559 0.69731,0.464875 3.27073,1.693475 3.40355,1.627064 4.66535,3.27073 1.26181,1.627064 1.26181,4.001249 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5381"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 305.82875,98.166821 q 1.92591,0 2.82245,-1.095778 0.89655,-1.11238 0.97956,-3.868427 l 0,-0.6143 q 0,-2.988485 -0.92975,-4.283495 -0.91315,-1.29501 -2.95528,-1.29501 -3.56958,0 -3.56958,5.61171 0,2.789253 0.87995,4.167276 0.89654,1.378024 2.77265,1.378024 z m -1.8097,3.968039 q -3.28733,0 -5.14683,-2.523605 -1.8595,-2.540212 -1.8595,-7.056144 0,-4.549138 1.8927,-7.105953 1.90931,-2.556815 5.21325,-2.556815 1.75988,0 3.0715,0.664108 1.31161,0.664108 2.30777,2.058734 l 0.13282,0 0.44827,-2.374185 4.2835,0 0,26.73034 -5.08042,0 0,-7.78667 q 0,-1.01276 0.21583,-2.78925 l -0.21583,0 q -0.81354,1.34482 -2.15835,2.04213 -1.34482,0.69731 -3.10471,0.69731 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5383"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.80812,101.80281 -0.68071,-2.374184 -0.26564,0 q -0.81353,1.295014 -2.30778,2.008924 -1.49424,0.69731 -3.40355,0.69731 -3.27073,0 -4.931,-1.74328 -1.66027,-1.759884 -1.66027,-5.047217 l 0,-12.103363 5.06382,0 0,10.841558 q 0,2.008926 0.71392,3.021691 0.71392,0.996161 2.27457,0.996161 2.12514,0 3.0715,-1.411229 0.94635,-1.427831 0.94635,-4.715165 l 0,-8.733016 5.06382,0 0,18.56181 -3.88503,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5385"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 353.82713,101.80281 -0.97956,-2.523609 -0.13282,0 q -1.27841,1.610459 -2.63983,2.241359 -1.34481,0.6143 -3.51977,0.6143 -2.67303,0 -4.21708,-1.52744 -1.52745,-1.527451 -1.52745,-4.349909 0,-2.955279 2.05874,-4.349905 2.07533,-1.411229 6.24261,-1.560654 l 3.22092,-0.09962 0,-0.813532 q 0,-2.822458 -2.88887,-2.822458 -2.22476,0 -5.22985,1.344819 L 342.5373,84.53601 q 3.20432,-1.676872 7.10595,-1.676872 3.73561,0 5.72793,1.627064 1.99233,1.627064 1.99233,4.947602 l 0,12.369006 -3.53638,0 z m -1.49424,-8.600194 -1.95912,0.06641 q -2.20816,0.06641 -3.28733,0.79693 -1.07918,0.730518 -1.07918,2.224761 0,2.141747 2.4572,2.141747 1.75989,0 2.80586,-1.012764 1.06257,-1.012765 1.06257,-2.689637 l 0,-1.527447 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5387"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 372.92024,82.892343 q 1.02936,0 1.71007,0.149424 l -0.38186,4.748371 q -0.6143,-0.166027 -1.49424,-0.166027 -2.42399,0 -3.78541,1.245202 -1.34482,1.245202 -1.34482,3.486565 l 0,9.446932 -5.06382,0 0,-18.56181 3.83522,0 0.74712,3.121306 0.24904,0 q 0.86334,-1.560653 2.32438,-2.507007 1.47764,-0.962956 3.20432,-0.962956 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5389"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 385.7209,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55681,-1.029367 z m 0.71391,15.639732 q -4.48273,0 -7.00633,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32437,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93484,0 6.12639,2.241364 2.19156,2.241363 2.19156,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67687,0 3.17111,-0.348656 1.49425,-0.348657 3.12131,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51085,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5391"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 421.71555,95.062117 q 0,3.287333 -2.37419,5.180043 -2.35758,1.8927 -6.57466,1.8927 -3.88503,0 -6.87352,-1.46103 l 0,-4.781578 q 2.4572,1.095778 4.15067,1.54405 1.71008,0.448273 3.12131,0.448273 1.69347,0 2.59002,-0.647505 0.91315,-0.647505 0.91315,-1.925912 0,-0.713916 -0.39847,-1.261805 -0.39846,-0.564492 -1.17879,-1.079175 -0.76372,-0.514684 -3.13791,-1.643667 -2.22476,-1.045969 -3.33714,-2.008926 -1.11238,-0.962956 -1.77649,-2.241363 -0.6641,-1.278408 -0.6641,-2.988485 0,-3.220922 2.17495,-5.063821 2.19155,-1.842899 6.04338,-1.842899 1.89271,0 3.60278,0.448272 1.72668,0.448273 3.60279,1.261805 l -1.66027,4.001249 q -1.94252,-0.796929 -3.22092,-1.11238 -1.26181,-0.315451 -2.49041,-0.315451 -1.46103,0 -2.24136,0.68071 -0.78033,0.68071 -0.78033,1.776488 0,0.680711 0.31545,1.195394 0.31545,0.498081 0.99616,0.979559 0.69732,0.464875 3.27074,1.693475 3.40355,1.627064 4.66535,3.27073 1.26181,1.627064 1.26181,4.001249 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5393"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 433.53667,98.10041 q 1.32822,0 3.18772,-0.581094 l 0,3.768814 q -1.89271,0.84673 -4.64876,0.84673 -3.03829,0 -4.43292,-1.52744 -1.37802,-1.544054 -1.37802,-4.615552 l 0,-8.948852 -2.42399,0 0,-2.141747 2.78925,-1.693475 1.46104,-3.918235 3.23752,0 0,3.951441 5.19665,0 0,3.802016 -5.19665,0 0,8.948852 q 0,1.079175 0.5977,1.593859 0.6143,0.514683 1.61046,0.514683 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5395"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 440.24416,78.442821 q 0,-2.473801 2.75605,-2.473801 2.75605,0 2.75605,2.473801 0,1.178792 -0.69732,1.842899 -0.68071,0.647505 -2.05873,0.647505 -2.75605,0 -2.75605,-2.490404 z m 5.27966,23.359989 -5.06382,0 0,-18.56181 5.06382,0 0,18.56181 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5397"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 458.3577,102.13486 q -8.66661,0 -8.66661,-9.513339 0,-4.731767 2.35758,-7.222171 2.35759,-2.507007 6.7573,-2.507007 3.22092,0 5.77774,1.261805 l -1.49425,3.918235 q -1.19539,-0.481478 -2.22476,-0.780326 -1.02936,-0.315451 -2.05873,-0.315451 -3.95144,0 -3.95144,5.61171 0,5.445683 3.95144,5.445683 1.46104,0 2.70624,-0.381862 1.2452,-0.398464 2.4904,-1.228599 l 0,4.333302 q -1.2286,0.78033 -2.4904,1.07918 -1.2452,0.29884 -3.15451,0.29884 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5399"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 473.1507,91.708373 2.20815,-2.822458 5.19665,-5.644915 5.71132,0 -7.37159,8.052306 7.81987,10.509504 -5.84415,0 -5.34607,-7.521019 -2.17495,1.743282 0,5.777737 -5.06382,0 0,-25.83379 5.06382,0 0,11.522269 -0.26564,4.217084 0.0664,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5401"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 497.09178,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55681,-1.029367 z m 0.71391,15.639732 q -4.48272,0 -7.00633,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32437,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93484,0 6.12639,2.241364 2.19156,2.241363 2.19156,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67687,0 3.17111,-0.348656 1.49425,-0.348657 3.12131,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51084,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5403"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 519.88728,82.892343 q 1.02936,0 1.71007,0.149424 l -0.38186,4.748371 q -0.6143,-0.166027 -1.49424,-0.166027 -2.42399,0 -3.78541,1.245202 -1.34482,1.245202 -1.34482,3.486565 l 0,9.446932 -5.06382,0 0,-18.56181 3.83522,0 0.74712,3.121306 0.24904,0 q 0.86334,-1.560653 2.32438,-2.507007 1.47764,-0.962956 3.20432,-0.962956 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5405"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 543.59592,101.80281 -5.14684,0 0,-19.989642 -6.59127,0 0,-4.283495 18.32937,0 0,4.283495 -6.59126,0 0,19.989642 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5407"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 561.24458,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91315,1.012764 -1.04597,2.888868 l 7.10595,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55681,-1.029367 z m 0.71391,15.639732 q -4.48272,0 -7.00633,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32437,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93484,0 6.1264,2.241364 2.19155,2.241363 2.19155,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.27841,3.370347 1.19539,1.211996 3.35374,1.211996 1.67687,0 3.17112,-0.348656 1.49424,-0.348657 3.1213,-1.112381 l 0,3.918234 q -1.32821,0.66411 -2.83906,0.97956 -1.51084,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5409"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 590.29929,101.80281 -5.06382,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10854,-1.012765 -1.94252,0 -2.82246,1.427832 -0.87994,1.427832 -0.87994,4.698562 l 0,8.733016 -5.06382,0 0,-18.56181 3.86843,0 0.68071,2.374185 0.28224,0 q 0.74712,-1.278407 2.15835,-1.992323 1.41123,-0.730519 3.23753,-0.730519 4.16727,0 5.64491,2.722842 l 0.44828,0 q 0.74712,-1.29501 2.19155,-2.008926 1.46104,-0.713916 3.28733,-0.713916 3.15452,0 4.76498,1.627064 1.62706,1.610461 1.62706,5.18004 l 0,12.103363 -5.08042,0 0,-10.841558 q 0,-2.008926 -0.68071,-3.005087 -0.66411,-1.012765 -2.10855,-1.012765 -1.8595,0 -2.78925,1.328216 -0.91315,1.328215 -0.91315,4.217084 l 0,9.31411 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5411"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 617.27868,102.13486 q -3.27073,0 -5.13023,-2.374181 l -0.26564,0 q 0.26564,2.324381 0.26564,2.689641 l 0,7.52102 -5.06382,0 0,-26.73034 4.11747,0 0.71391,2.40739 0.23244,0 q 1.77649,-2.756047 5.26306,-2.756047 3.28733,0 5.14683,2.540212 1.8595,2.540212 1.8595,7.056145 0,2.971882 -0.87994,5.163437 -0.86334,2.191556 -2.4738,3.337143 -1.61046,1.14558 -3.78542,1.14558 z M 615.78444,86.9434 q -1.8761,0 -2.73944,1.162189 -0.86334,1.145586 -0.89655,3.802017 l 0,0.547888 q 0,2.988485 0.87994,4.283495 0.89655,1.29501 2.82246,1.29501 3.40355,0 3.40355,-5.61171 0,-2.739444 -0.84673,-4.100865 -0.83014,-1.378024 -2.62323,-1.378024 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5413"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 633.66554,101.80281 -5.06382,0 0,-25.83379 5.06382,0 0,25.83379 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5415"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 650.74968,101.80281 -0.97956,-2.523609 -0.13282,0 q -1.27841,1.610459 -2.63983,2.241359 -1.34482,0.6143 -3.51977,0.6143 -2.67303,0 -4.21708,-1.52744 -1.52745,-1.527451 -1.52745,-4.349909 0,-2.955279 2.05873,-4.349905 2.07534,-1.411229 6.24261,-1.560654 l 3.22093,-0.09962 0,-0.813532 q 0,-2.822458 -2.88887,-2.822458 -2.22476,0 -5.22985,1.344819 l -1.67687,-3.420155 q 3.20432,-1.676872 7.10595,-1.676872 3.73561,0 5.72793,1.627064 1.99232,1.627064 1.99232,4.947602 l 0,12.36901 -3.53637,0 z m -1.49424,-8.600194 -1.95912,0.06641 q -2.20816,0.06641 -3.28733,0.79693 -1.07918,0.730518 -1.07918,2.224761 0,2.141747 2.4572,2.141747 1.75988,0 2.80585,-1.012764 1.06258,-1.012765 1.06258,-2.689637 l 0,-1.527447 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5417"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 667.30257,98.10041 q 1.32822,0 3.18772,-0.581094 l 0,3.768814 q -1.89271,0.84673 -4.64876,0.84673 -3.03829,0 -4.43292,-1.52744 -1.37802,-1.544054 -1.37802,-4.615552 l 0,-8.948852 -2.42399,0 0,-2.141747 2.78925,-1.693475 1.46104,-3.918235 3.23752,0 0,3.951441 5.19665,0 0,3.802016 -5.19665,0 0,8.948852 q 0,1.079175 0.5977,1.593859 0.6143,0.514683 1.61046,0.514683 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5419"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 681.91297,86.495128 q -1.61046,0 -2.52361,1.029367 -0.91314,1.012764 -1.04597,2.888868 l 7.10596,0 q -0.0332,-1.876104 -0.97956,-2.888868 -0.94635,-1.029367 -2.55682,-1.029367 z m 0.71392,15.639732 q -4.48273,0 -7.00634,-2.473797 -2.52361,-2.473801 -2.52361,-7.006336 0,-4.665357 2.32438,-7.205569 2.34098,-2.556815 6.45845,-2.556815 3.93484,0 6.12639,2.241364 2.19156,2.241363 2.19156,6.192804 l 0,2.457199 -11.97054,0 q 0.083,2.15835 1.2784,3.370347 1.1954,1.211996 3.35375,1.211996 1.67687,0 3.17111,-0.348656 1.49424,-0.348657 3.12131,-1.112381 l 0,3.918234 q -1.32822,0.66411 -2.83906,0.97956 -1.51085,0.33205 -3.6858,0.33205 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5421"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
        transform="translate(178.67433,582.63783)"
-       xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:29.74009705px;line-height:120.00000477%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="-85.936043"
-       y="-454.19525"
-       id="text8216"
-       sodipodi:linespacing="120%"><tspan
-         id="tspan8220"
-         sodipodi:role="line"
-         x="-85.936043"
-         y="-454.19525"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start">(This template follows the StickerConstructorSpec at github.com/terinjokes/StickerconstructorSpec)</tspan></text>
+       id="text8216">
+      <path
+         d="m -85.433484,-457.63349 q 0,-1.62412 0.471914,-3.03986 0.478044,-1.41575 1.372843,-2.48215 l 0.992859,0 q -0.882541,1.18285 -1.329941,2.59859 -0.441271,1.41575 -0.441271,2.91117 0,1.4709 0.453528,2.87438 0.453529,1.40349 1.305427,2.56183 l -0.980602,0 q -0.900928,-1.04189 -1.372843,-2.43312 -0.471914,-1.39123 -0.471914,-2.99084 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5424"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -78.219932,-454.19525 -1.04189,0 0,-8.03481 -2.837616,0 0,-0.92544 6.717122,0 0,0.92544 -2.837616,0 0,8.03481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5426"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -69.596764,-454.19525 0,-4.34529 q 0,-0.82126 -0.373855,-1.22576 -0.373854,-0.40449 -1.170593,-0.40449 -1.060276,0 -1.550577,0.5761 -0.484172,0.5761 -0.484172,1.88766 l 0,3.51178 -1.017374,0 0,-9.53635 1.017374,0 0,2.88664 q 0,0.52095 -0.04903,0.86416 l 0.06129,0 q 0.30031,-0.48417 0.851898,-0.75997 0.557718,-0.28192 1.268654,-0.28192 1.231881,0 1.844757,0.58836 0.619005,0.58223 0.619005,1.85701 l 0,4.38207 -1.017374,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5428"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -65.478238,-454.19525 -1.017374,0 0,-6.71712 1.017374,0 0,6.71712 z m -1.103177,-8.53737 q 0,-0.34934 0.171606,-0.50868 0.171605,-0.16548 0.429013,-0.16548 0.24515,0 0.422884,0.16548 0.177735,0.16547 0.177735,0.50868 0,0.34321 -0.177735,0.51482 -0.177734,0.16548 -0.422884,0.16548 -0.257408,0 -0.429013,-0.16548 -0.171606,-0.17161 -0.171606,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5430"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -58.975621,-456.02775 q 0,0.9377 -0.698679,1.44639 -0.698679,0.50868 -1.961204,0.50868 -1.33607,0 -2.083779,-0.42288 l 0,-0.94383 q 0.484172,0.24515 1.035761,0.38611 0.557717,0.14096 1.072533,0.14096 0.796739,0 1.225753,-0.25128 0.429013,-0.2574 0.429013,-0.77835 0,-0.39224 -0.343211,-0.66803 -0.337082,-0.28193 -1.323812,-0.66191 -0.937701,-0.34934 -1.33607,-0.60675 -0.392241,-0.26353 -0.588361,-0.59449 -0.189992,-0.33095 -0.189992,-0.79061 0,-0.82125 0.668035,-1.29317 0.668035,-0.47804 1.8325,-0.47804 1.084791,0 2.120551,0.44127 l -0.361597,0.82738 q -1.011245,-0.41675 -1.832499,-0.41675 -0.723194,0 -1.09092,0.22676 -0.367726,0.22677 -0.367726,0.62514 0,0.26966 0.134833,0.45965 0.140962,0.19 0.4474,0.3616 0.306438,0.17161 1.176722,0.49643 1.195108,0.43514 1.611864,0.87641 0.422885,0.44127 0.422885,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5432"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -51.896902,-454.91232 q 0.269666,0 0.520945,-0.0368 0.251279,-0.0429 0.398369,-0.0858 l 0,0.77835 q -0.165476,0.0797 -0.490301,0.1287 -0.318695,0.0552 -0.576103,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962216,0 0,-0.4903 0.962216,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948946,0 0,0.79061 -1.948946,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5434"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -46.791642,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151196,-0.95609 1.262525,0 1.997976,0.83351 0.735451,0.82739 0.735451,2.18797 l 0,0.64352 -4.627215,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145067,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.023504,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808996,0 -1.293168,0.52707 -0.478044,0.52708 -0.563846,1.45865 l 3.51178,0 q 0,-0.96222 -0.429013,-1.47091 -0.429014,-0.51481 -1.225753,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5436"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -34.031562,-454.19525 0,-4.36981 q 0,-0.80287 -0.343211,-1.20124 -0.34321,-0.40449 -1.066404,-0.40449 -0.949958,0 -1.403487,0.54546 -0.453528,0.54546 -0.453528,1.67928 l 0,3.7508 -1.017374,0 0,-4.36981 q 0,-0.80287 -0.343211,-1.20124 -0.343211,-0.40449 -1.072533,-0.40449 -0.956087,0 -1.403487,0.5761 -0.44127,0.56997 -0.44127,1.8754 l 0,3.52404 -1.017375,0 0,-6.71712 0.827383,0 0.165476,0.91931 0.04903,0 q 0.288051,-0.4903 0.808996,-0.76609 0.527074,-0.2758 1.176722,-0.2758 1.575092,0 2.059264,1.13995 l 0.04903,0 q 0.30031,-0.52707 0.870284,-0.83351 0.569975,-0.30644 1.299298,-0.30644 1.139949,0 1.703795,0.58836 0.569975,0.58223 0.569975,1.86927 l 0,4.38207 -1.017374,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5438"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -27.798611,-454.07268 q -0.655777,0 -1.201237,-0.23902 -0.539331,-0.24515 -0.907057,-0.74771 l -0.07355,0 q 0.07355,0.58836 0.07355,1.11544 l 0,2.76407 -1.017374,0 0,-9.73247 0.827383,0 0.140961,0.91931 0.04903,0 q 0.392241,-0.55159 0.913186,-0.79674 0.520944,-0.24515 1.195108,-0.24515 1.33607,0 2.059264,0.91319 0.729323,0.91318 0.729323,2.56182 0,1.65476 -0.74158,2.57408 -0.735452,0.91318 -2.047007,0.91318 z m -0.14709,-6.09811 q -1.029632,0 -1.489289,0.56997 -0.459657,0.56998 -0.471915,1.81411 l 0,0.22677 q 0,1.41574 0.471915,2.02862 0.471915,0.60675 1.513804,0.60675 0.870284,0 1.360585,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.490301,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5440"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -22.209181,-454.19525 -1.017375,0 0,-9.53635 1.017375,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5442"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -15.908816,-454.19525 -0.202249,-0.95609 -0.04903,0 q -0.502559,0.63126 -1.005117,0.85803 -0.49643,0.22063 -1.244139,0.22063 -0.998988,0 -1.568963,-0.51481 -0.563846,-0.51482 -0.563846,-1.46478 0,-2.03474 3.254373,-2.13281 l 1.139949,-0.0368 0,-0.41675 q 0,-0.79061 -0.34321,-1.16447 -0.337082,-0.37998 -1.084791,-0.37998 -0.83964,0 -1.899916,0.51481 l -0.312567,-0.77835 q 0.49643,-0.26966 1.084791,-0.42288 0.59449,-0.15322 1.188979,-0.15322 1.201238,0 1.777341,0.5332 0.582233,0.5332 0.582233,1.70992 l 0,4.58432 -0.753838,0 z m -2.298286,-0.71707 q 0.949958,0 1.489289,-0.52094 0.54546,-0.52095 0.54546,-1.45865 l 0,-0.60674 -1.017374,0.0429 q -1.213495,0.0429 -1.752826,0.37998 -0.533202,0.33095 -0.533202,1.03576 0,0.55159 0.330953,0.83964 0.337082,0.28805 0.9377,0.28805 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5444"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -10.883226,-454.91232 q 0.269665,0 0.520945,-0.0368 0.251279,-0.0429 0.3983691,-0.0858 l 0,0.77835 q -0.1654761,0.0797 -0.4903011,0.1287 -0.318695,0.0552 -0.576103,0.0552 -1.948947,0 -1.948947,-2.05313 l 0,-3.99595 -0.962215,0 0,-0.4903 0.962215,-0.42289 0.429014,-1.43413 0.588361,0 0,1.55671 1.948946,0 0,0.79061 -1.948946,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288051,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5446"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -5.7779734,-454.07268 q -1.4892891,0 -2.3534444,-0.90705 -0.8580266,-0.90706 -0.8580266,-2.51892 0,-1.62413 0.7967389,-2.58021 0.8028678,-0.95609 2.1511953,-0.95609 1.2625249,0 1.9979762,0.83351 0.7354514,0.82739 0.7354514,2.18797 l 0,0.64352 -4.6272149,0 q 0.030644,1.18285 0.5944899,1.79573 0.5699748,0.61287 1.5996067,0.61287 1.0847908,0 2.1450665,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.0235031,0.33095 -0.4780434,0.10419 -1.1583359,0.10419 z m -0.2757943,-6.11037 q -0.8089965,0 -1.2931687,0.52707 -0.4780434,0.52708 -0.563846,1.45865 l 3.5117803,0 q 0,-0.96222 -0.4290133,-1.47091 -0.4290133,-0.51481 -1.2257523,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5448"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 4.7083362,-460.12176 -1.7099244,0 0,5.92651 -1.0173744,0 0,-5.92651 -1.20123728,0 0,-0.45966 1.20123728,-0.36773 0,-0.37385 q 0,-2.47602 2.1634528,-2.47602 0.5332022,0 1.2502673,0.21451 l -0.2635367,0.81512 q -0.5883611,-0.18999 -1.0051169,-0.18999 -0.5761036,0 -0.8518979,0.38611 -0.2757942,0.37998 -0.2757942,1.22575 l 0,0.43515 1.7099244,0 0,0.79061 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5450"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 11.744154,-457.55994 q 0,1.64251 -0.827383,2.56795 -0.827383,0.91931 -2.2860281,0.91931 -0.9009279,0 -1.5996067,-0.42288 -0.6986788,-0.42289 -1.078662,-1.2135 -0.3799832,-0.79061 -0.3799832,-1.85088 0,-1.64251 0.821254,-2.5557 0.821254,-0.91931 2.2798993,-0.91931 1.4096147,0 2.2369977,0.9377 0.833512,0.9377 0.833512,2.53731 z m -5.1175161,0 q 0,1.28704 0.514816,1.9612 0.514816,0.67417 1.5138041,0.67417 0.9989881,0 1.513804,-0.66804 0.520945,-0.67416 0.520945,-1.96733 0,-1.28091 -0.520945,-1.94282 -0.5148159,-0.66803 -1.5260615,-0.66803 -0.9989882,0 -1.5076754,0.65577 -0.5086872,0.65578 -0.5086872,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5452"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 14.538869,-454.19525 -1.017374,0 0,-9.53635 1.017374,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5454"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 17.725828,-454.19525 -1.017375,0 0,-9.53635 1.017375,0 0,9.53635 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5456"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 25.69322,-457.55994 q 0,1.64251 -0.827383,2.56795 -0.827383,0.91931 -2.286028,0.91931 -0.900928,0 -1.599607,-0.42288 -0.698678,-0.42289 -1.078662,-1.2135 -0.379983,-0.79061 -0.379983,-1.85088 0,-1.64251 0.821254,-2.5557 0.821254,-0.91931 2.279899,-0.91931 1.409616,0 2.236998,0.9377 0.833512,0.9377 0.833512,2.53731 z m -5.117516,0 q 0,1.28704 0.514816,1.9612 0.514816,0.67417 1.513804,0.67417 0.998988,0 1.513804,-0.66804 0.520945,-0.67416 0.520945,-1.96733 0,-1.28091 -0.520945,-1.94282 -0.514816,-0.66803 -1.526061,-0.66803 -0.998988,0 -1.507676,0.65577 -0.508687,0.65578 -0.508687,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5458"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 32.955803,-454.19525 -1.231881,-3.9408 q -0.116447,-0.36159 -0.435142,-1.6425 l -0.04903,0 q -0.24515,1.07253 -0.429013,1.65476 l -1.268654,3.92854 -1.176722,0 -1.832499,-6.71712 1.066404,0 q 0.649649,2.53117 0.986731,3.85499 0.34321,1.32381 0.39224,1.78347 l 0.04903,0 q 0.06742,-0.34934 0.214506,-0.90093 0.153219,-0.55772 0.263537,-0.88254 l 1.231881,-3.85499 1.103177,0 1.201237,3.85499 q 0.343211,1.05414 0.465786,1.77121 l 0.04903,0 q 0.02452,-0.22064 0.128704,-0.68029 0.110318,-0.45966 1.280911,-4.94591 l 1.054147,0 -1.857014,6.71712 -1.207366,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5460"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 41.560584,-456.02775 q 0,0.9377 -0.698679,1.44639 -0.698679,0.50868 -1.961203,0.50868 -1.33607,0 -2.083779,-0.42288 l 0,-0.94383 q 0.484172,0.24515 1.03576,0.38611 0.557718,0.14096 1.072534,0.14096 0.796739,0 1.225752,-0.25128 0.429013,-0.2574 0.429013,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.337082,-0.28193 -1.323813,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.392241,-0.26353 -0.588361,-0.59449 -0.189992,-0.33095 -0.189992,-0.79061 0,-0.82125 0.668035,-1.29317 0.668035,-0.47804 1.8325,-0.47804 1.084791,0 2.120551,0.44127 l -0.361596,0.82738 q -1.011246,-0.41675 -1.8325,-0.41675 -0.723194,0 -1.09092,0.22676 -0.367725,0.22677 -0.367725,0.62514 0,0.26966 0.134832,0.45965 0.140962,0.19 0.4474,0.3616 0.306438,0.17161 1.176722,0.49643 1.195109,0.43514 1.611864,0.87641 0.422885,0.44127 0.422885,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5462"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 48.639303,-454.91232 q 0.269666,0 0.520945,-0.0368 0.251279,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.165477,0.0797 -0.490301,0.1287 -0.318696,0.0552 -0.576104,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962216,0 0,-0.4903 0.962216,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948947,0 0,0.79061 -1.948947,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5464"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 55.503518,-454.19525 0,-4.34529 q 0,-0.82126 -0.373854,-1.22576 -0.373855,-0.40449 -1.170594,-0.40449 -1.060275,0 -1.550576,0.5761 -0.484172,0.5761 -0.484172,1.88766 l 0,3.51178 -1.017375,0 0,-9.53635 1.017375,0 0,2.88664 q 0,0.52095 -0.04903,0.86416 l 0.06129,0 q 0.300309,-0.48417 0.851898,-0.75997 0.557717,-0.28192 1.268654,-0.28192 1.231881,0 1.844757,0.58836 0.619005,0.58223 0.619005,1.85701 l 0,4.38207 -1.017375,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5466"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 61.442287,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151195,-0.95609 1.262525,0 1.997977,0.83351 0.735451,0.82739 0.735451,2.18797 l 0,0.64352 -4.627215,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145066,-0.45352 l 0,0.90705 q -0.539331,0.23289 -1.023503,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808997,0 -1.293169,0.52707 -0.478043,0.52708 -0.563846,1.45865 l 3.511781,0 q 0,-0.96222 -0.429014,-1.47091 -0.429013,-0.51481 -1.225752,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5468"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 74.110428,-456.57934 q 0,1.18285 -0.858026,1.84476 -0.858027,0.6619 -2.32893,0.6619 -1.593478,0 -2.451504,-0.41062 l 0,-1.00512 q 0.551588,0.23289 1.201237,0.36773 0.649649,0.13483 1.28704,0.13483 1.041889,0 1.568963,-0.39224 0.527073,-0.39837 0.527073,-1.10318 0,-0.46579 -0.189991,-0.75997 -0.183863,-0.30031 -0.625134,-0.55158 -0.435142,-0.25128 -1.329941,-0.56998 -1.250268,-0.4474 -1.789599,-1.06027 -0.533202,-0.61288 -0.533202,-1.59961 0,-1.03576 0.778353,-1.64864 0.778353,-0.61287 2.059264,-0.61287 1.33607,0 2.457633,0.4903 l -0.324824,0.90705 q -1.109306,-0.46578 -2.157324,-0.46578 -0.827383,0 -1.293169,0.35547 -0.465786,0.35546 -0.465786,0.98673 0,0.46578 0.171606,0.76609 0.171605,0.29418 0.576103,0.54546 0.410627,0.24515 1.250267,0.54546 1.409616,0.50256 1.936689,1.07866 0.533202,0.57611 0.533202,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5470"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 77.959296,-454.91232 q 0.269665,0 0.520944,-0.0368 0.251279,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.165477,0.0797 -0.490301,0.1287 -0.318696,0.0552 -0.576104,0.0552 -1.948946,0 -1.948946,-2.05313 l 0,-3.99595 -0.962215,0 0,-0.4903 0.962215,-0.42289 0.429013,-1.43413 0.588361,0 0,1.55671 1.948947,0 0,0.79061 -1.948947,0 0,3.95305 q 0,0.60674 0.288052,0.93157 0.288052,0.32482 0.790611,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5472"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 81.244314,-454.19525 -1.017375,0 0,-6.71712 1.017375,0 0,6.71712 z m -1.103177,-8.53737 q 0,-0.34934 0.171605,-0.50868 0.171605,-0.16548 0.429013,-0.16548 0.245151,0 0.422885,0.16548 0.177734,0.16547 0.177734,0.50868 0,0.34321 -0.177734,0.51482 -0.177734,0.16548 -0.422885,0.16548 -0.257408,0 -0.429013,-0.16548 -0.171605,-0.17161 -0.171605,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5474"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.098287,-454.07268 q -1.458645,0 -2.261512,-0.8948 -0.796739,-0.90092 -0.796739,-2.54343 0,-1.68541 0.808996,-2.60473 0.815125,-0.91931 2.316672,-0.91931 0.484172,0 0.968344,0.10419 0.484172,0.10419 0.759967,0.24515 l -0.312567,0.86416 q -0.337082,-0.13484 -0.735452,-0.22064 -0.398369,-0.0919 -0.704807,-0.0919 -2.047006,0 -2.047006,2.61085 0,1.23801 0.496429,1.89992 0.502559,0.6619 1.48316,0.6619 0.839641,0 1.722182,-0.36159 l 0,0.90092 q -0.674163,0.34934 -1.697667,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5476"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.400681,-457.63349 q 0.263537,-0.37385 0.802868,-0.9806 l 2.169581,-2.29828 1.207366,0 -2.72117,2.86213 2.911162,3.85499 -1.231881,0 -2.371831,-3.1747 -0.766095,0.66191 0,2.51279 -1.005117,0 0,-9.53635 1.005117,0 0,5.05622 q 0,0.33709 -0.04903,1.04189 l 0.04903,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5478"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 98.827724,-454.07268 q -1.489289,0 -2.353444,-0.90705 -0.858027,-0.90706 -0.858027,-2.51892 0,-1.62413 0.796739,-2.58021 0.802868,-0.95609 2.151195,-0.95609 1.262525,0 1.997973,0.83351 0.73546,0.82739 0.73546,2.18797 l 0,0.64352 -4.62722,0 q 0.03064,1.18285 0.59449,1.79573 0.569975,0.61287 1.599607,0.61287 1.084791,0 2.145063,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.478043,0.10419 -1.158336,0.10419 z m -0.275794,-6.11037 q -0.808997,0 -1.293169,0.52707 -0.478043,0.52708 -0.563846,1.45865 l 3.511785,0 q 0,-0.96222 -0.429018,-1.47091 -0.429013,-0.51481 -1.225752,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5480"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.09032,-461.03495 q 0.4474,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5482"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 112.1394,-462.35263 q -1.47703,0 -2.33506,0.98673 -0.8519,0.9806 -0.8519,2.69052 0,1.75896 0.82126,2.72117 0.82738,0.95609 2.35344,0.95609 0.9377,0 2.13894,-0.33708 l 0,0.91318 q -0.93157,0.34934 -2.29828,0.34934 -1.97959,0 -3.05826,-1.20123 -1.07253,-1.20124 -1.07253,-3.41372 0,-1.3851 0.51482,-2.42699 0.52094,-1.04189 1.49541,-1.60574 0.98061,-0.56384 2.30442,-0.56384 1.40961,0 2.46376,0.51481 l -0.44127,0.8948 q -1.01737,-0.47804 -2.03475,-0.47804 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5484"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 121.86575,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99898,0 1.5138,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5486"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 128.23965,-454.19525 0,-4.34529 q 0,-0.82126 -0.37386,-1.22576 -0.37385,-0.40449 -1.17059,-0.40449 -1.05415,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.31256,-0.49643 0.87641,-0.76609 0.56385,-0.2758 1.2564,-0.2758 1.21349,0 1.82637,0.58836 0.61287,0.58223 0.61287,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5488"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 135.67385,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.9612,0.50868 -1.33607,0 -2.08378,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55772,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.33708,-0.28193 -1.32381,-0.66191 -0.93771,-0.34934 -1.33607,-0.60675 -0.39225,-0.26353 -0.58837,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66804,-1.29317 0.66803,-0.47804 1.8325,-0.47804 1.08479,0 2.12055,0.44127 l -0.3616,0.82738 q -1.01124,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36772,0.22677 -0.36772,0.62514 0,0.26966 0.13483,0.45965 0.14096,0.19 0.4474,0.3616 0.30644,0.17161 1.17672,0.49643 1.19511,0.43514 1.61187,0.87641 0.42288,0.44127 0.42288,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5490"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 139.49206,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5492"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 144.82408,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14096,0.94383 q -0.41676,-0.0919 -0.73545,-0.0919 -0.81513,0 -1.39736,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37385,-0.65577 0.90092,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5494"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 147.83943,-460.91237 0,4.35755 q 0,0.82125 0.37385,1.22575 0.37386,0.4045 1.1706,0.4045 1.05414,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31257,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83863,-0.58223 -0.60674,-0.58223 -0.60674,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5496"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 157.26546,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5498"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 162.73232,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25127,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.49031,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5500"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 170.79777,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5502"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 175.6395,-461.03495 q 0.44739,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81513,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01738,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5504"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 182.90822,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85802,0.6619 -2.32893,0.6619 -1.59348,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55159,0.23289 1.20124,0.36773 0.64964,0.13483 1.28704,0.13483 1.04188,0 1.56896,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62513,-0.55158 -0.43515,-0.25128 -1.32994,-0.56998 -1.25027,-0.4474 -1.7896,-1.06027 -0.53321,-0.61288 -0.53321,-1.59961 0,-1.03576 0.77836,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45763,0.4903 l -0.32482,0.90705 q -1.10931,-0.46578 -2.15732,-0.46578 -0.82739,0 -1.29317,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40961,0.50256 1.93669,1.07866 0.5332,0.57611 0.5332,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5506"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 187.71314,-454.07268 q -0.65578,0 -1.20123,-0.23902 -0.53934,-0.24515 -0.90706,-0.74771 l -0.0736,0 q 0.0736,0.58836 0.0736,1.11544 l 0,2.76407 -1.01738,0 0,-9.73247 0.82739,0 0.14096,0.91931 0.049,0 q 0.39224,-0.55159 0.91318,-0.79674 0.52095,-0.24515 1.19511,-0.24515 1.33607,0 2.05927,0.91319 0.72932,0.91318 0.72932,2.56182 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.04701,0.91318 z m -0.14709,-6.09811 q -1.02963,0 -1.48929,0.56997 -0.45965,0.56998 -0.47191,1.81411 l 0,0.22677 q 0,1.41574 0.47191,2.02862 0.47192,0.60675 1.51381,0.60675 0.87028,0 1.36058,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.4903,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5508"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 195.12281,-454.07268 q -1.48929,0 -2.35344,-0.90705 -0.85803,-0.90706 -0.85803,-2.51892 0,-1.62413 0.79674,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99797,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62721,0 q 0.0306,1.18285 0.59449,1.79573 0.56997,0.61287 1.59961,0.61287 1.08479,0 2.14506,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.47804,0.10419 -1.15834,0.10419 z m -0.27579,-6.11037 q -0.809,0 -1.29317,0.52707 -0.47804,0.52708 -0.56385,1.45865 l 3.51179,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5510"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 202.00542,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5512"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 212.694,-454.19525 -0.20225,-0.95609 -0.049,0 q -0.50256,0.63126 -1.00512,0.85803 -0.49643,0.22063 -1.24414,0.22063 -0.99899,0 -1.56896,-0.51481 -0.56385,-0.51482 -0.56385,-1.46478 0,-2.03474 3.25438,-2.13281 l 1.13995,-0.0368 0,-0.41675 q 0,-0.79061 -0.34321,-1.16447 -0.33709,-0.37998 -1.0848,-0.37998 -0.83964,0 -1.89991,0.51481 l -0.31257,-0.77835 q 0.49643,-0.26966 1.08479,-0.42288 0.59449,-0.15322 1.18898,-0.15322 1.20124,0 1.77734,0.5332 0.58224,0.5332 0.58224,1.70992 l 0,4.58432 -0.75384,0 z m -2.29829,-0.71707 q 0.94996,0 1.48929,-0.52094 0.54546,-0.52095 0.54546,-1.45865 l 0,-0.60674 -1.01737,0.0429 q -1.2135,0.0429 -1.75283,0.37998 -0.5332,0.33095 -0.5332,1.03576 0,0.55159 0.33095,0.83964 0.33708,0.28805 0.9377,0.28805 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5514"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 217.71958,-454.91232 q 0.26967,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16547,0.0797 -0.4903,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94894,0 0,0.79061 -1.94894,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5516"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 228.74522,-460.91237 0,0.64352 -1.24414,0.14709 q 0.17161,0.2145 0.30644,0.56384 0.13483,0.34321 0.13483,0.77835 0,0.98674 -0.67416,1.5751 -0.67416,0.58836 -1.85089,0.58836 -0.30031,0 -0.56384,-0.049 -0.64965,0.34321 -0.64965,0.86415 0,0.2758 0.22676,0.41063 0.22677,0.1287 0.77836,0.1287 l 1.18898,0 q 1.09091,0 1.67315,0.45966 0.58836,0.45966 0.58836,1.33607 0,1.11544 -0.8948,1.69767 -0.8948,0.58836 -2.61085,0.58836 -1.31769,0 -2.03475,-0.4903 -0.71094,-0.4903 -0.71094,-1.3851 0,-0.61288 0.39224,-1.06028 0.39224,-0.4474 1.10318,-0.60674 -0.25741,-0.11645 -0.43514,-0.3616 -0.17161,-0.24515 -0.17161,-0.56998 0,-0.36772 0.19612,-0.64352 0.19612,-0.27579 0.61901,-0.5332 -0.52095,-0.21451 -0.8519,-0.72932 -0.32483,-0.51482 -0.32483,-1.17672 0,-1.10318 0.66191,-1.69767 0.66191,-0.60062 1.8754,-0.60062 0.52708,0 0.94996,0.12258 l 2.3228,0 z m -5.35654,7.84481 q 0,0.54546 0.45966,0.82738 0.45966,0.28193 1.31768,0.28193 1.28092,0 1.89379,-0.38612 0.61901,-0.37998 0.61901,-1.03576 0,-0.54546 -0.33709,-0.75996 -0.33708,-0.20838 -1.26865,-0.20838 l -1.21962,0 q -0.69255,0 -1.07866,0.33095 -0.38612,0.33096 -0.38612,0.94996 z m 0.55159,-5.69362 q 0,0.70481 0.39837,1.06641 0.39837,0.36159 1.10931,0.36159 1.48929,0 1.48929,-1.44639 0,-1.5138 -1.50768,-1.5138 -0.71706,0 -1.10318,0.38611 -0.38611,0.38611 -0.38611,1.14608 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5518"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 231.15383,-454.19525 -1.01738,0 0,-6.71712 1.01738,0 0,6.71712 z m -1.10318,-8.53737 q 0,-0.34934 0.17161,-0.50868 0.1716,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.25741,0 -0.42901,-0.16548 -0.17161,-0.17161 -0.17161,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5520"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 235.49299,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5522"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 242.3572,-454.19525 0,-4.34529 q 0,-0.82126 -0.37385,-1.22576 -0.37386,-0.40449 -1.1706,-0.40449 -1.06027,0 -1.55057,0.5761 -0.48417,0.5761 -0.48417,1.88766 l 0,3.51178 -1.01738,0 0,-9.53635 1.01738,0 0,2.88664 q 0,0.52095 -0.049,0.86416 l 0.0613,0 q 0.30031,-0.48417 0.8519,-0.75997 0.55772,-0.28192 1.26865,-0.28192 1.23189,0 1.84476,0.58836 0.61901,0.58223 0.61901,1.85701 l 0,4.38207 -1.01738,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5524"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 246.41444,-460.91237 0,4.35755 q 0,0.82125 0.37386,1.22575 0.37385,0.4045 1.17059,0.4045 1.05415,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31256,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83862,-0.58223 -0.60675,-0.58223 -0.60675,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5526"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 256.28175,-461.02269 q 1.32381,0 2.05313,0.90705 0.73545,0.90093 0.73545,2.5557 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.047,0.91318 -0.65578,0 -1.20124,-0.23902 -0.53933,-0.24515 -0.90706,-0.74771 l -0.0735,0 -0.21451,0.86416 -0.72932,0 0,-9.53635 1.01737,0 0,2.31667 q 0,0.77835 -0.049,1.39736 l 0.049,0 q 0.71094,-1.00512 2.1083,-1.00512 z m -0.14709,0.8519 q -1.04189,0 -1.50155,0.60061 -0.45966,0.59449 -0.45966,2.01024 0,1.41574 0.47192,2.02862 0.47191,0.60675 1.5138,0.60675 0.9377,0 1.39736,-0.6803 0.45966,-0.68642 0.45966,-1.96733 0,-1.31155 -0.45966,-1.95507 -0.45966,-0.64352 -1.42187,-0.64352 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5528"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 260.70671,-454.8449 q 0,-0.41063 0.18386,-0.61901 0.19,-0.2145 0.53933,-0.2145 0.35547,0 0.55159,0.2145 0.20225,0.20838 0.20225,0.61901 0,0.39837 -0.20225,0.61288 -0.20225,0.2145 -0.55159,0.2145 -0.31256,0 -0.52094,-0.18999 -0.20225,-0.19612 -0.20225,-0.63739 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5530"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 266.87224,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5532"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 275.96731,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5534"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 286.30655,-454.19525 0,-4.36981 q 0,-0.80287 -0.34321,-1.20124 -0.34321,-0.40449 -1.06641,-0.40449 -0.94995,0 -1.40348,0.54546 -0.45353,0.54546 -0.45353,1.67928 l 0,3.7508 -1.01737,0 0,-4.36981 q 0,-0.80287 -0.34322,-1.20124 -0.34321,-0.40449 -1.07253,-0.40449 -0.95609,0 -1.40348,0.5761 -0.44128,0.56997 -0.44128,1.8754 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.28805,-0.4903 0.809,-0.76609 0.52707,-0.2758 1.17672,-0.2758 1.57509,0 2.05926,1.13995 l 0.049,0 q 0.30031,-0.52707 0.87029,-0.83351 0.56997,-0.30644 1.29929,-0.30644 1.13995,0 1.7038,0.58836 0.56997,0.58223 0.56997,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5536"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 292.81529,-463.1555 -3.34017,8.96025 -1.01738,0 3.34018,-8.96025 1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5538"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 296.19224,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28806,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5540"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 301.2975,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79673,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53934,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29317,0.52707 -0.47804,0.52708 -0.56384,1.45865 l 3.51178,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5542"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 308.56009,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14097,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5544"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 311.63671,-454.19525 -1.01738,0 0,-6.71712 1.01738,0 0,6.71712 z m -1.10318,-8.53737 q 0,-0.34934 0.17161,-0.50868 0.1716,-0.16548 0.42901,-0.16548 0.24515,0 0.42288,0.16548 0.17774,0.16547 0.17774,0.50868 0,0.34321 -0.17774,0.51482 -0.17773,0.16548 -0.42288,0.16548 -0.25741,0 -0.42901,-0.16548 -0.17161,-0.17161 -0.17161,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5546"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 318.40286,-454.19525 0,-4.34529 q 0,-0.82126 -0.37386,-1.22576 -0.37385,-0.40449 -1.17059,-0.40449 -1.05415,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16547,0.91931 0.049,0 q 0.31257,-0.49643 0.87642,-0.76609 0.56384,-0.2758 1.25639,-0.2758 1.2135,0 1.82637,0.58836 0.61288,0.58223 0.61288,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5548"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 320.68888,-451.1799 q -0.58223,0 -0.94383,-0.15322 l 0,-0.82738 q 0.42289,0.12257 0.83352,0.12257 0.47804,0 0.69867,-0.26353 0.22677,-0.25741 0.22677,-0.79061 l 0,-7.8203 1.01737,0 0,7.74675 q 0,1.98572 -1.8325,1.98572 z m 0.72933,-11.55272 q 0,-0.34934 0.1716,-0.50868 0.17161,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.2574,0 -0.42901,-0.16548 -0.1716,-0.17161 -0.1716,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5550"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 330.4888,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82739,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82125,-0.91931 2.2799,-0.91931 1.40961,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11752,0 q 0,1.28704 0.51482,1.9612 0.51481,0.67417 1.5138,0.67417 0.99899,0 1.51381,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52607,-0.66803 -0.99898,0 -1.50767,0.65577 -0.50869,0.65578 -0.50869,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5552"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 333.27124,-457.63349 q 0.26354,-0.37385 0.80287,-0.9806 l 2.16958,-2.29828 1.20737,0 -2.72117,2.86213 2.91116,3.85499 -1.23188,0 -2.37183,-3.1747 -0.7661,0.66191 0,2.51279 -1.00512,0 0,-9.53635 1.00512,0 0,5.05622 q 0,0.33709 -0.049,1.04189 l 0.049,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5554"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 341.69828,-454.07268 q -1.48929,0 -2.35344,-0.90705 -0.85803,-0.90706 -0.85803,-2.51892 0,-1.62413 0.79674,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26252,0 1.99797,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62721,0 q 0.0306,1.18285 0.59449,1.79573 0.56997,0.61287 1.59961,0.61287 1.08479,0 2.14506,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.0235,0.33095 -0.47804,0.10419 -1.15834,0.10419 z m -0.27579,-6.11037 q -0.809,0 -1.29317,0.52707 -0.47804,0.52708 -0.56385,1.45865 l 3.51179,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5556"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.22953,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.9612,0.50868 -1.33607,0 -2.08378,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55772,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34321,-0.66803 -0.33709,-0.28193 -1.32382,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.39224,-0.26353 -0.58836,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66804,-1.29317 0.66803,-0.47804 1.8325,-0.47804 1.08479,0 2.12055,0.44127 l -0.3616,0.82738 q -1.01124,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36772,0.22677 -0.36772,0.62514 0,0.26966 0.13483,0.45965 0.14096,0.19 0.4474,0.3616 0.30644,0.17161 1.17672,0.49643 1.19511,0.43514 1.61186,0.87641 0.42289,0.44127 0.42289,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5558"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 355.27962,-463.1555 -3.34018,8.96025 -1.01737,0 3.34017,-8.96025 1.01738,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5560"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 361.69643,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85803,0.6619 -2.32893,0.6619 -1.59348,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55158,0.23289 1.20123,0.36773 0.64965,0.13483 1.28704,0.13483 1.04189,0 1.56897,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62514,-0.55158 -0.43514,-0.25128 -1.32994,-0.56998 -1.25026,-0.4474 -1.7896,-1.06027 -0.5332,-0.61288 -0.5332,-1.59961 0,-1.03576 0.77836,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45763,0.4903 l -0.32482,0.90705 q -1.10931,-0.46578 -2.15733,-0.46578 -0.82738,0 -1.29316,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40961,0.50256 1.93668,1.07866 0.53321,0.57611 0.53321,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5562"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 365.54529,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.57611,0.0552 -1.94894,0 -1.94894,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28806,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5564"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.83031,-454.19525 -1.01737,0 0,-6.71712 1.01737,0 0,6.71712 z m -1.10317,-8.53737 q 0,-0.34934 0.1716,-0.50868 0.17161,-0.16548 0.42901,-0.16548 0.24515,0 0.42289,0.16548 0.17773,0.16547 0.17773,0.50868 0,0.34321 -0.17773,0.51482 -0.17774,0.16548 -0.42289,0.16548 -0.2574,0 -0.42901,-0.16548 -0.1716,-0.17161 -0.1716,-0.51482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5566"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.68429,-454.07268 q -1.45865,0 -2.26152,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81513,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31256,0.86416 q -0.33709,-0.13484 -0.73546,-0.22064 -0.39836,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69766,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5568"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 377.98669,-457.63349 q 0.26354,-0.37385 0.80287,-0.9806 l 2.16958,-2.29828 1.20737,0 -2.72117,2.86213 2.91116,3.85499 -1.23188,0 -2.37183,-3.1747 -0.7661,0.66191 0,2.51279 -1.00511,0 0,-9.53635 1.00511,0 0,5.05622 q 0,0.33709 -0.049,1.04189 l 0.049,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5570"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 386.41374,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79674,-2.58021 0.80286,-0.95609 2.15119,-0.95609 1.26253,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29316,0.52707 -0.47805,0.52708 -0.56385,1.45865 l 3.51178,0 q 0,-0.96222 -0.42901,-1.47091 -0.42902,-0.51481 -1.22576,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5572"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 393.6763,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14096,0.94383 q -0.41676,-0.0919 -0.73546,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11645,1.24413 0.049,0 q 0.37385,-0.65577 0.90092,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5574"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.41997,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96834,0.10419 0.48418,0.10419 0.75997,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.70481,-0.0919 -2.047,0 -2.047,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5576"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 407.51504,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82738,0.91931 -2.28603,0.91931 -0.90093,0 -1.5996,-0.42288 -0.69868,-0.42289 -1.07867,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11751,0 q 0,1.28704 0.51481,1.9612 0.51482,0.67417 1.51381,0.67417 0.99899,0 1.5138,-0.66804 0.52095,-0.67416 0.52095,-1.96733 0,-1.28091 -0.52095,-1.94282 -0.51481,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50868,0.65578 -0.50868,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5578"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 413.88897,-454.19525 0,-4.34529 q 0,-0.82126 -0.37385,-1.22576 -0.37386,-0.40449 -1.1706,-0.40449 -1.05414,0 -1.54445,0.56997 -0.4903,0.56998 -0.4903,1.88153 l 0,3.52404 -1.01737,0 0,-6.71712 0.82738,0 0.16548,0.91931 0.049,0 q 0.31257,-0.49643 0.87641,-0.76609 0.56385,-0.2758 1.2564,-0.2758 1.21349,0 1.82637,0.58836 0.61287,0.58223 0.61287,1.86927 l 0,4.38207 -1.01737,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5580"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 421.32316,-456.02775 q 0,0.9377 -0.69868,1.44639 -0.69868,0.50868 -1.96121,0.50868 -1.33607,0 -2.08377,-0.42288 l 0,-0.94383 q 0.48417,0.24515 1.03576,0.38611 0.55771,0.14096 1.07253,0.14096 0.79674,0 1.22575,-0.25128 0.42902,-0.2574 0.42902,-0.77835 0,-0.39224 -0.34322,-0.66803 -0.33708,-0.28193 -1.32381,-0.66191 -0.9377,-0.34934 -1.33607,-0.60675 -0.39224,-0.26353 -0.58836,-0.59449 -0.18999,-0.33095 -0.18999,-0.79061 0,-0.82125 0.66803,-1.29317 0.66804,-0.47804 1.8325,-0.47804 1.0848,0 2.12056,0.44127 l -0.3616,0.82738 q -1.01125,-0.41675 -1.8325,-0.41675 -0.72319,0 -1.09092,0.22676 -0.36773,0.22677 -0.36773,0.62514 0,0.26966 0.13484,0.45965 0.14096,0.19 0.4474,0.3616 0.30643,0.17161 1.17672,0.49643 1.19511,0.43514 1.61186,0.87641 0.42289,0.44127 0.42289,1.10931 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5582"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.14136,-454.91232 q 0.26967,0 0.52095,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16548,0.0797 -0.4903,0.1287 -0.3187,0.0552 -0.57611,0.0552 -1.94894,0 -1.94894,-2.05313 l 0,-3.99595 -0.96222,0 0,-0.4903 0.96222,-0.42289 0.42901,-1.43413 0.58836,0 0,1.55671 1.94895,0 0,0.79061 -1.94895,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5584"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 430.47342,-461.03495 q 0.4474,0 0.80287,0.0735 l -0.14097,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39735,0.66191 -0.57611,0.66191 -0.57611,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52708,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5586"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 433.48872,-460.91237 0,4.35755 q 0,0.82125 0.37386,1.22575 0.37385,0.4045 1.17059,0.4045 1.05415,0 1.53832,-0.57611 0.4903,-0.5761 0.4903,-1.88153 l 0,-3.53016 1.01737,0 0,6.71712 -0.83964,0 -0.14709,-0.90093 -0.0552,0 q -0.31256,0.49643 -0.87028,0.75997 -0.55159,0.26353 -1.26253,0.26353 -1.22575,0 -1.83862,-0.58223 -0.60675,-0.58223 -0.60675,-1.86314 l 0,-4.39432 1.02963,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5588"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 442.91479,-454.07268 q -1.45865,0 -2.26152,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81513,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31256,0.86416 q -0.33709,-0.13484 -0.73546,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69766,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5590"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 448.38166,-454.91232 q 0.26966,0 0.52094,-0.0368 0.25128,-0.0429 0.39837,-0.0858 l 0,0.77835 q -0.16547,0.0797 -0.4903,0.1287 -0.31869,0.0552 -0.5761,0.0552 -1.94895,0 -1.94895,-2.05313 l 0,-3.99595 -0.96221,0 0,-0.4903 0.96221,-0.42289 0.42902,-1.43413 0.58836,0 0,1.55671 1.94894,0 0,0.79061 -1.94894,0 0,3.95305 q 0,0.60674 0.28805,0.93157 0.28805,0.32482 0.79061,0.32482 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5592"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 456.44708,-457.55994 q 0,1.64251 -0.82738,2.56795 -0.82739,0.91931 -2.28603,0.91931 -0.90093,0 -1.59961,-0.42288 -0.69868,-0.42289 -1.07866,-1.2135 -0.37998,-0.79061 -0.37998,-1.85088 0,-1.64251 0.82125,-2.5557 0.82126,-0.91931 2.2799,-0.91931 1.40962,0 2.237,0.9377 0.83351,0.9377 0.83351,2.53731 z m -5.11752,0 q 0,1.28704 0.51482,1.9612 0.51482,0.67417 1.5138,0.67417 0.99899,0 1.51381,-0.66804 0.52094,-0.67416 0.52094,-1.96733 0,-1.28091 -0.52094,-1.94282 -0.51482,-0.66803 -1.52606,-0.66803 -0.99899,0 -1.50768,0.65577 -0.50869,0.65578 -0.50869,1.95508 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5594"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.28879,-461.03495 q 0.4474,0 0.80286,0.0735 l -0.14096,0.94383 q -0.41675,-0.0919 -0.73545,-0.0919 -0.81512,0 -1.39736,0.66191 -0.5761,0.66191 -0.5761,1.64864 l 0,3.60371 -1.01737,0 0,-6.71712 0.83964,0 0.11644,1.24413 0.049,0 q 0.37386,-0.65577 0.90093,-1.01124 0.52707,-0.35547 1.15834,-0.35547 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5596"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.55751,-456.57934 q 0,1.18285 -0.85803,1.84476 -0.85802,0.6619 -2.32893,0.6619 -1.59347,0 -2.4515,-0.41062 l 0,-1.00512 q 0.55159,0.23289 1.20124,0.36773 0.64965,0.13483 1.28704,0.13483 1.04189,0 1.56896,-0.39224 0.52707,-0.39837 0.52707,-1.10318 0,-0.46579 -0.18999,-0.75997 -0.18386,-0.30031 -0.62513,-0.55158 -0.43514,-0.25128 -1.32994,-0.56998 -1.25027,-0.4474 -1.7896,-1.06027 -0.5332,-0.61288 -0.5332,-1.59961 0,-1.03576 0.77835,-1.64864 0.77835,-0.61287 2.05926,-0.61287 1.33607,0 2.45764,0.4903 l -0.32483,0.90705 q -1.1093,-0.46578 -2.15732,-0.46578 -0.82738,0 -1.29317,0.35547 -0.46579,0.35546 -0.46579,0.98673 0,0.46578 0.17161,0.76609 0.1716,0.29418 0.5761,0.54546 0.41063,0.24515 1.25027,0.54546 1.40962,0.50256 1.93669,1.07866 0.5332,0.57611 0.5332,1.49542 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5598"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 473.36246,-454.07268 q -0.65577,0 -1.20123,-0.23902 -0.53933,-0.24515 -0.90706,-0.74771 l -0.0735,0 q 0.0735,0.58836 0.0735,1.11544 l 0,2.76407 -1.01737,0 0,-9.73247 0.82738,0 0.14096,0.91931 0.049,0 q 0.39224,-0.55159 0.91319,-0.79674 0.52094,-0.24515 1.1951,-0.24515 1.33607,0 2.05927,0.91319 0.72932,0.91318 0.72932,2.56182 0,1.65476 -0.74158,2.57408 -0.73545,0.91318 -2.04701,0.91318 z m -0.14709,-6.09811 q -1.02963,0 -1.48928,0.56997 -0.45966,0.56998 -0.47192,1.81411 l 0,0.22677 q 0,1.41574 0.47192,2.02862 0.47191,0.60675 1.5138,0.60675 0.87028,0 1.36058,-0.70481 0.49643,-0.70481 0.49643,-1.94282 0,-1.2564 -0.49643,-1.92443 -0.4903,-0.67416 -1.3851,-0.67416 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5600"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 480.77217,-454.07268 q -1.48929,0 -2.35345,-0.90705 -0.85802,-0.90706 -0.85802,-2.51892 0,-1.62413 0.79673,-2.58021 0.80287,-0.95609 2.1512,-0.95609 1.26253,0 1.99798,0.83351 0.73545,0.82739 0.73545,2.18797 l 0,0.64352 -4.62722,0 q 0.0306,1.18285 0.59449,1.79573 0.56998,0.61287 1.59961,0.61287 1.08479,0 2.14507,-0.45352 l 0,0.90705 q -0.53933,0.23289 -1.02351,0.33095 -0.47804,0.10419 -1.15833,0.10419 z m -0.2758,-6.11037 q -0.80899,0 -1.29317,0.52707 -0.47804,0.52708 -0.56384,1.45865 l 3.51178,0 q 0,-0.96222 -0.42902,-1.47091 -0.42901,-0.51481 -1.22575,-0.51481 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5602"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 487.65471,-454.07268 q -1.45864,0 -2.26151,-0.8948 -0.79674,-0.90092 -0.79674,-2.54343 0,-1.68541 0.809,-2.60473 0.81512,-0.91931 2.31667,-0.91931 0.48417,0 0.96835,0.10419 0.48417,0.10419 0.75996,0.24515 l -0.31257,0.86416 q -0.33708,-0.13484 -0.73545,-0.22064 -0.39837,-0.0919 -0.7048,-0.0919 -2.04701,0 -2.04701,2.61085 0,1.23801 0.49643,1.89992 0.50256,0.6619 1.48316,0.6619 0.83964,0 1.72218,-0.36159 l 0,0.90092 q -0.67416,0.34934 -1.69767,0.34934 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5604"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 493.08482,-457.63349 q 0,1.61187 -0.47805,3.0031 -0.47191,1.39123 -1.36671,2.42086 l -0.9806,0 q 0.85189,-1.15221 1.30542,-2.5557 0.45353,-1.40961 0.45353,-2.88051 0,-1.49542 -0.4474,-2.91117 -0.44127,-1.41574 -1.32381,-2.59859 l 0.99286,0 q 0.90093,1.07253 1.37284,2.49441 0.47192,1.41574 0.47192,3.0276 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5606"
+         inkscape:connector-curvature="0" />
+    </g>
     <rect
        transform="translate(178.67433,582.63783)"
        style="opacity:1;fill:none;fill-opacity:1;stroke:#0093d9;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000003, 4.00000005;stroke-dashoffset:6.5;stroke-opacity:1"
@@ -119,83 +713,971 @@
        height="21.23"
        x="38.762836"
        y="69.453773" />
-    <text
-       xml:space="preserve"
+    <g
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="255.83966"
-       y="580.09589"
-       id="text8536"
-       sodipodi:linespacing="521%"><tspan
-         sodipodi:role="line"
-         id="tspan8538"
-         x="255.83966"
-         y="580.09589"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Safe area <tspan
-   style="font-weight:normal"
-   id="tspan8540">- Keep all text inside this border</tspan></tspan></text>
-    <text
-       sodipodi:linespacing="521%"
-       id="text8542"
-       y="624.09589"
-       x="255.83966"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+       id="text8536">
+      <path
+         d="m 263.32035,577.19507 q 0,1.41468 -1.02172,2.2292 -1.01457,0.81451 -2.82937,0.81451 -1.6719,0 -2.95798,-0.62875 l 0,-2.05772 q 1.05744,0.47156 1.78622,0.66447 0.73592,0.19292 1.34323,0.19292 0.72878,0 1.1146,-0.27865 0.39297,-0.27865 0.39297,-0.82881 0,-0.30723 -0.17147,-0.54301 -0.17148,-0.24293 -0.50729,-0.46442 -0.32866,-0.22149 -1.35038,-0.70734 -0.95741,-0.45013 -1.43612,-0.86453 -0.47871,-0.4144 -0.7645,-0.96456 -0.2858,-0.55015 -0.2858,-1.28608 0,-1.3861 0.93598,-2.17918 0.94312,-0.79308 2.60074,-0.79308 0.81451,0 1.55043,0.19291 0.74307,0.19291 1.55044,0.54301 l -0.71449,1.72191 q -0.83595,-0.34295 -1.3861,-0.4787 -0.54301,-0.13576 -1.07173,-0.13576 -0.62875,0 -0.96456,0.29294 -0.33581,0.29294 -0.33581,0.76451 0,0.29294 0.13575,0.51443 0.13575,0.21434 0.42869,0.42154 0.30009,0.20006 1.40754,0.72878 1.4647,0.7002 2.00771,1.40754 0.54302,0.7002 0.54302,1.72192 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="624.09589"
-         x="255.83966"
-         id="tspan8544"
-         sodipodi:role="line">Trim <tspan
-   id="tspan8546"
-   style="font-weight:normal">- Outer edge of sticker</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="255.83966"
-       y="668.09589"
-       id="text8548"
-       sodipodi:linespacing="521%"><tspan
-         sodipodi:role="line"
-         id="tspan8550"
-         x="255.83966"
-         y="668.09589"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
-           style="font-weight:normal"
-           id="tspan8552"><tspan
-   style="font-weight:bold"
-   id="tspan8554">Bleed</tspan> - This area will be trimmed off</tspan></tspan></text>
-    <text
-       sodipodi:linespacing="521%"
-       id="text8556"
-       y="748.41248"
-       x="326.5592"
-       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
+         id="path5919"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 270.11512,580.09589 -0.42155,-1.08602 -0.0572,0 q -0.55016,0.69305 -1.13604,0.96455 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88596,-1.87196 0.89311,-0.60731 2.68648,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.24321,-1.21462 -0.95741,0 -2.25063,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.058,-0.72164 1.6076,0 2.46499,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46441,0.31438 -0.46441,0.95742 0,0.92169 1.05744,0.92169 0.75735,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         y="748.41248"
-         x="326.5592"
-         id="tspan8558"
-         sodipodi:role="line">Make sure you:</tspan></text>
-    <text
-       xml:space="preserve"
+         id="path5921"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 278.28886,573.74409 -1.88625,0 0,6.3518 -2.17918,0 0,-6.3518 -1.20034,0 0,-1.05029 1.20034,-0.58588 0,-0.58588 q 0,-1.36468 0.67161,-1.99342 0.67162,-0.62875 2.15061,-0.62875 1.12889,0 2.00771,0.33581 l -0.5573,1.60045 q -0.65733,-0.2072 -1.21463,-0.2072 -0.46441,0 -0.67162,0.27865 -0.2072,0.2715 -0.2072,0.70019 l 0,0.50015 1.88625,0 0,1.63617 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5923"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 282.84014,573.50831 q -0.69305,0 -1.08602,0.44298 -0.39296,0.43584 -0.45012,1.24321 l 3.058,0 q -0.0143,-0.80737 -0.42154,-1.24321 -0.40726,-0.44298 -1.10032,-0.44298 z m 0.30723,6.73047 q -1.92911,0 -3.01513,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63645,0.96456 0.94313,0.96456 0.94313,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92884 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72164,0 1.36467,-0.15005 0.64304,-0.15004 1.34324,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65019,0.14289 -1.58617,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5925"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 297.06559,580.09589 -0.42154,-1.08602 -0.0572,0 q -0.55016,0.69305 -1.13604,0.96455 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88597,-1.87196 0.89311,-0.60731 2.68647,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.2432,-1.21462 -0.95742,0 -2.25064,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.05801,-0.72164 1.60759,0 2.46498,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46441,0.31438 -0.46441,0.95742 0,0.92169 1.05744,0.92169 0.75736,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5927"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 305.2822,571.95787 q 0.44298,0 0.73592,0.0643 l -0.16433,2.04343 q -0.26436,-0.0715 -0.64304,-0.0715 -1.04315,0 -1.62903,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98797 1.65046,0 0.32152,1.34323 0.10718,0 q 0.37153,-0.67162 1.00028,-1.07887 0.63589,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5929"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 310.7909,573.50831 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92884 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5931"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 321.21527,580.09589 -0.42155,-1.08602 -0.0572,0 q -0.55015,0.69305 -1.13603,0.96455 -0.57874,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65732 -0.65733,-0.65733 -0.65733,-1.87196 0,-1.27179 0.88596,-1.87196 0.89311,-0.60731 2.68648,-0.67162 l 1.3861,-0.0429 0,-0.3501 q 0,-1.21462 -1.24321,-1.21462 -0.95741,0 -2.25063,0.57873 l -0.72163,-1.47184 q 1.37896,-0.72164 3.058,-0.72164 1.6076,0 2.46498,0.7002 0.85739,0.7002 0.85739,2.12917 l 0,5.32294 -1.52186,0 z m -0.64304,-3.70105 -0.84309,0.0286 q -0.95027,0.0286 -1.41469,0.34295 -0.46442,0.31438 -0.46442,0.95742 0,0.92169 1.05745,0.92169 0.75735,0 1.20748,-0.43584 0.45727,-0.43584 0.45727,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5933"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 328.23154,576.71636 0,-1.08602 3.50813,0 0,1.08602 -3.50813,0 z"
+         style="font-weight:normal"
+         id="path5935"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 345.12917,580.09589 -1.42897,0 -3.80822,-5.06572 -1.09317,0.9717 0,4.09402 -1.21463,0 0,-10.44581 1.21463,0 0,5.18003 4.73705,-5.18003 1.43612,0 -4.20118,4.53699 4.35837,5.90882 z"
+         style="font-weight:normal"
+         id="path5937"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 349.6876,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50015,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5939"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 357.88992,580.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92884,-3.00799 0.93597,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86482,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5941"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 366.42804,580.23878 q -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 q 0.0857,0.68591 0.0857,1.30037 l 0,3.22233 -1.18604,0 0,-11.34606 0.96455,0 0.16434,1.07173 0.0571,0 q 0.45728,-0.64303 1.06459,-0.92883 0.60732,-0.28579 1.39325,-0.28579 1.55758,0 2.40068,1.06458 0.85024,1.06459 0.85024,2.98656 0,1.92912 -0.86453,3.00085 -0.85739,1.06458 -2.38639,1.06458 z m -0.17148,-7.10915 q -1.20033,0 -1.7362,0.66448 -0.53587,0.66447 -0.55016,2.11488 l 0,0.26436 q 0,1.65047 0.55016,2.36495 0.55016,0.70735 1.76478,0.70735 1.01458,0 1.58617,-0.82166 0.57873,-0.82167 0.57873,-2.26493 0,-1.4647 -0.57873,-2.24349 -0.57159,-0.78594 -1.61475,-0.78594 z"
+         style="font-weight:normal"
+         id="path5943"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 380.37484,580.09589 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25721 -1.45041,0.25721 -1.16461,0 -1.82909,-0.60017 -0.65732,-0.60017 -0.65732,-1.70762 0,-2.3721 3.79392,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26465,-0.44299 -0.97884,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.49299 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60732 0.63589,-0.60731 0.63589,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.62161,0.38583 -0.62161,1.20749 0,0.64304 0.38583,0.97885 0.39296,0.33581 1.09316,0.33581 z"
+         style="font-weight:normal"
+         id="path5945"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 384.8904,580.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5947"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.60573,580.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5949"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 397.46539,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5951"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 403.41706,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5953"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 410.19755,576.08761 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05772,-3.00085 1.3361,0 -2.7222,3.82251 2.86509,4.00828 -1.34323,0 -2.19348,-3.17233 -2.21491,3.17233 -1.34324,0 2.8651,-4.00828 z"
+         style="font-weight:normal"
+         id="path5955"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 418.49989,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5957"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.13062,580.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5959"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 434.01856,580.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66448 -0.57159,0.66447 -0.57159,2.19347 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02172,-0.89311 0.65733,-0.32151 1.4647,-0.32151 1.41468,0 2.12917,0.6859 0.71449,0.67877 0.71449,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5961"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 442.6853,577.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56445,0.28579 1.20749,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.17891,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path5963"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 445.79332,580.09589 -1.18604,0 0,-7.83079 1.18604,0 0,7.83079 z m -1.28607,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-weight:normal"
+         id="path5965"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 453.65268,579.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53614,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.37209,0.20006 q 1.21462,0 1.75764,-0.65733 0.55015,-0.66448 0.55015,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76478,-0.71449 -1.04316,0 -1.60046,0.81452 -0.55015,0.80737 -0.55015,2.28636 0,1.50042 0.55015,2.26492 0.55016,0.76451 1.61475,0.76451 z"
+         style="font-weight:normal"
+         id="path5967"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 460.60465,580.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.55731,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5969"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 471.82925,579.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5971"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 479.8315,580.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18604,0 0,-11.11743 1.18604,0 0,3.36524 q 0,0.60731 -0.0571,1.00742 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65019,-0.32866 1.47899,-0.32866 1.43612,0 2.15061,0.6859 0.72163,0.67877 0.72163,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5973"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 484.63286,580.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28607,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-weight:normal"
+         id="path5975"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 492.21357,577.95957 q 0,1.09316 -0.81451,1.68619 -0.81452,0.59302 -2.28636,0.59302 -1.55759,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56444,0.28579 1.20748,0.45012 0.65019,0.16434 1.25036,0.16434 0.92883,0 1.42897,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.54329,-0.77165 -1.09317,-0.40726 -1.55759,-0.70734 -0.45727,-0.30723 -0.6859,-0.69306 -0.2215,-0.38582 -0.2215,-0.92169 0,-0.95741 0.7788,-1.50756 0.77879,-0.5573 2.13631,-0.5573 1.26465,0 2.47213,0.51443 l -0.42155,0.96455 q -1.1789,-0.48585 -2.13631,-0.48585 -0.8431,0 -1.27179,0.26436 -0.4287,0.26436 -0.4287,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52158,0.42154 0.35724,0.20006 1.37181,0.57874 1.39325,0.50729 1.87911,1.02172 0.49299,0.51443 0.49299,1.29322 z"
+         style="font-weight:normal"
+         id="path5977"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 501.58051,572.1365 q 1.54329,0 2.39353,1.05744 0.85739,1.05029 0.85739,2.97941 0,1.92912 -0.86453,3.00085 -0.85739,1.06458 -2.38639,1.06458 -0.7645,0 -1.4004,-0.27865 -0.62875,-0.28579 -1.05744,-0.87167 l -0.0857,0 -0.25007,1.00743 -0.85024,0 0,-11.11743 1.18605,0 0,2.70076 q 0,0.9074 -0.0572,1.62903 l 0.0572,0 q 0.82881,-1.17175 2.45784,-1.17175 z m -0.17148,0.99313 q -1.21463,0 -1.75049,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65047 0.55016,2.36495 0.55015,0.70735 1.76478,0.70735 1.09317,0 1.62903,-0.79309 0.53587,-0.80022 0.53587,-2.2935 0,-1.529 -0.53587,-2.27922 -0.53586,-0.75021 -1.65761,-0.75021 z"
+         style="font-weight:normal"
+         id="path5979"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 513.66964,576.17335 q 0,1.91483 -0.96456,2.9937 -0.96455,1.07173 -2.66504,1.07173 -1.05029,0 -1.86481,-0.49299 -0.81451,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09316 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75763,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-weight:normal"
+         id="path5981"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 519.3141,572.12221 q 0.52157,0 0.93598,0.0857 l -0.16434,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61445,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5983"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 527.04485,579.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53615,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55016,-0.66448 0.55016,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76479,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55016,0.80737 -0.55016,2.28636 0,1.50042 0.55016,2.26492 0.55016,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path5985"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 533.99682,580.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5987"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 542.46348,572.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5989"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8542">
+      <path
+         d="m 261.18403,624.09589 -2.21491,0 0,-8.60243 -2.83652,0 0,-1.84338 7.88794,0 0,1.84338 -2.83651,0 0,8.60243 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5872"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 269.92935,615.95787 q 0.44299,0 0.73593,0.0643 l -0.16434,2.04343 q -0.26436,-0.0715 -0.64303,-0.0715 -1.04316,0 -1.62904,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98797 1.65047,0 0.32152,1.34323 0.10717,0 q 0.37153,-0.67162 1.00028,-1.07887 0.6359,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5874"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.03709,614.04305 q 0,-1.06459 1.18605,-1.06459 1.18605,0 1.18605,1.06459 0,0.50728 -0.30008,0.79308 -0.29294,0.27865 -0.88597,0.27865 -1.18605,0 -1.18605,-1.07173 z m 2.27207,10.05284 -2.17918,0 0,-7.98797 2.17918,0 0,7.98797 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5876"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.7404,624.09589 -2.17919,0 0,-4.66561 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.83595,0 -1.21463,0.61446 -0.37867,0.61446 -0.37867,2.022 l 0,3.75821 -2.17919,0 0,-7.98797 1.66475,0 0.29294,1.02171 0.12147,0 q 0.32152,-0.55015 0.92883,-0.85738 0.60732,-0.31438 1.39325,-0.31438 1.79337,0 2.42926,1.17176 l 0.19291,0 q 0.32152,-0.5573 0.94312,-0.86453 0.62875,-0.30723 1.41469,-0.30723 1.35753,0 2.05058,0.7002 0.7002,0.69305 0.7002,2.2292 l 0,5.20862 -2.18634,0 0,-4.66561 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.90739,-0.43584 -0.80023,0 -1.20034,0.57159 -0.39297,0.57159 -0.39297,1.8148 l 0,4.00828 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5878"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 294.22193,620.71636 0,-1.08602 3.50813,0 0,1.08602 -3.50813,0 z"
+         style="font-weight:normal"
+         id="path5880"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 312.64142,618.85869 q 0,2.50785 -1.27179,3.94397 -1.26464,1.43612 -3.52242,1.43612 -2.3078,0 -3.5653,-1.40754 -1.25035,-1.41468 -1.25035,-3.98684 0,-2.55072 1.2575,-3.95111 1.2575,-1.40754 3.57244,-1.40754 2.25063,0 3.51527,1.42897 1.26465,1.42898 1.26465,3.94397 z m -8.32378,0 q 0,2.12203 0.90025,3.22234 0.9074,1.09317 2.62932,1.09317 1.7362,0 2.62217,-1.09317 0.88596,-1.09316 0.88596,-3.22234 0,-2.10774 -0.88596,-3.19376 -0.87882,-1.09316 -2.60788,-1.09316 -1.73621,0 -2.64361,1.10031 -0.90025,1.09316 -0.90025,3.18661 z"
+         style="font-weight:normal"
+         id="path5882"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 315.91377,616.2651 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47157 1.36467,0.47157 1.22892,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17147,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47184,0.30723 -1.42898,0 -2.14347,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-weight:normal"
+         id="path5884"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 326.30242,623.25994 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19292,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.3358,0.37868 0.92168,0.37868 z"
+         style="font-weight:normal"
+         id="path5886"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.25411,624.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50786,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5888"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 340.72078,616.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95026,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5890"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 350.23061,624.23878 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92884,-3.00799 0.93597,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86482,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5892"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 360.45492,623.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53615,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85738,-3.00799 0.85739,-1.07173 2.38639,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15719,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55016,-0.66448 0.55016,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55016,-0.71449 -1.76479,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55015,0.80737 -0.55015,2.28636 0,1.50042 0.55015,2.26492 0.55016,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path5894"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 370.50777,616.2651 0,0.75021 -1.45041,0.17148 q 0.20005,0.25007 0.35724,0.65733 0.15719,0.40011 0.15719,0.9074 0,1.15032 -0.78594,1.83623 -0.78593,0.68591 -2.15775,0.68591 -0.3501,0 -0.65733,-0.0572 -0.75736,0.40011 -0.75736,1.00743 0,0.32152 0.26437,0.47871 0.26436,0.15004 0.90739,0.15004 l 1.38611,0 q 1.27179,0 1.95055,0.53586 0.68591,0.53587 0.68591,1.55759 0,1.30036 -1.04315,1.97913 -1.04315,0.6859 -3.04372,0.6859 -1.53615,0 -2.3721,-0.57159 -0.8288,-0.57159 -0.8288,-1.61474 0,-0.71448 0.45727,-1.23606 0.45727,-0.52158 1.28608,-0.70734 -0.30009,-0.13576 -0.50729,-0.42155 -0.20006,-0.2858 -0.20006,-0.66447 0,-0.4287 0.22864,-0.75022 0.22864,-0.32152 0.72163,-0.6216 -0.60731,-0.25007 -0.99314,-0.85024 -0.37867,-0.60017 -0.37867,-1.37182 0,-1.28607 0.77164,-1.97913 0.77165,-0.70019 2.18633,-0.70019 0.61446,0 1.10746,0.14289 l 2.70791,0 z m -6.24462,9.14544 q 0,0.6359 0.53586,0.96456 0.53587,0.32867 1.53615,0.32867 1.49328,0 2.20777,-0.45013 0.72163,-0.44298 0.72163,-1.20749 0,-0.63589 -0.39297,-0.88596 -0.39297,-0.24293 -1.47899,-0.24293 l -1.42183,0 q -0.80737,0 -1.2575,0.38583 -0.45012,0.38582 -0.45012,1.10745 z m 0.64304,-6.63759 q 0,0.82166 0.46441,1.24321 0.46442,0.42155 1.29322,0.42155 1.73621,0 1.73621,-1.68619 0,-1.76478 -1.75764,-1.76478 -0.83595,0 -1.28608,0.45012 -0.45012,0.45013 -0.45012,1.33609 z"
+         style="font-weight:normal"
+         id="path5896"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 375.43773,624.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50015,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5898"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 390.8921,620.17335 q 0,1.91483 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.05029,0 -1.86481,-0.49299 -0.81452,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97941 0.95742,-1.07173 2.6579,-1.07173 1.64332,0 2.60788,1.09316 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75764,0.7645 -0.59302,0.76451 -0.59302,2.27922 z"
+         style="font-weight:normal"
+         id="path5900"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.49369,617.18679 -1.99342,0 0,6.9091 -1.18605,0 0,-6.9091 -1.4004,0 0,-0.53586 1.4004,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.6216,0 1.45755,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32151,0.44298 -0.32151,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z"
+         style="font-weight:normal"
+         id="path5902"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.78944,621.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42925,-0.49299 l 0,-1.10031 q 0.56444,0.28579 1.20748,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.1789,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path5904"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 411.2407,623.25994 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5906"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 415.07035,624.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20005,-0.19291 0.50014,-0.19291 0.28579,0 0.49299,0.19291 0.20721,0.19291 0.20721,0.59302 0,0.40012 -0.20721,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5908"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 420.7291,624.23878 q -1.70048,0 -2.63646,-1.04315 -0.92883,-1.05029 -0.92883,-2.96512 0,-1.96484 0.94312,-3.03657 0.95027,-1.07173 2.70076,-1.07173 0.56445,0 1.1289,0.12146 0.56444,0.12146 0.88596,0.28579 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85738,-0.25721 -0.46442,-0.10718 -0.82166,-0.10718 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57873,2.21491 0.58588,0.77165 1.72906,0.77165 0.97885,0 2.00771,-0.42155 l 0,1.0503 q -0.78593,0.40725 -1.97913,0.40725 z"
+         style="font-weight:normal"
+         id="path5910"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.74479,620.08761 q 0.30723,-0.43584 0.93598,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17233,3.33666 3.39382,4.49413 -1.43612,0 -2.76507,-3.70105 -0.89311,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-weight:normal"
+         id="path5912"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.56901,624.23878 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93654 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5914"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 444.03569,616.12221 q 0.52157,0 0.93597,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.4144 1.35039,-0.4144 z"
+         style="font-weight:normal"
+         id="path5916"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8548">
+      <path
+         d="m 257.15432,657.65008 3.25092,0 q 2.22205,0 3.22233,0.63589 1.00743,0.62875 1.00743,2.00771 0,0.93598 -0.44298,1.53615 -0.43584,0.60017 -1.16461,0.72163 l 0,0.0715 q 0.99313,0.22149 1.42897,0.82881 0.44298,0.60731 0.44298,1.61474 0,1.42897 -1.036,2.2292 -1.02887,0.80023 -2.8008,0.80023 l -3.90824,0 0,-10.44581 z m 2.21491,4.13688 1.28608,0 q 0.90025,0 1.30036,-0.27865 0.40726,-0.27865 0.40726,-0.92169 0,-0.60017 -0.44298,-0.85738 -0.43584,-0.26436 -1.38611,-0.26436 l -1.16461,0 0,2.32208 z m 0,1.75764 0,2.7222 1.44326,0 q 0.91455,0 1.35039,-0.3501 0.43583,-0.3501 0.43583,-1.07173 0,-1.30037 -1.85766,-1.30037 l -1.37182,0 z"
+         style="font-weight:bold"
+         id="path5813"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 268.99338,668.09589 -2.17919,0 0,-11.11743 2.17919,0 0,11.11743 z"
+         style="font-weight:bold"
+         id="path5815"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 274.58067,661.50831 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92884 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-weight:bold"
+         id="path5817"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 283.24026,661.50831 q -0.69306,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92884 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72164,0 1.36468,-0.15005 0.64303,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-weight:bold"
+         id="path5819"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 291.12106,668.23878 q -1.40755,0 -2.21492,-1.09316 -0.80022,-1.09317 -0.80022,-3.02943 0,-1.96484 0.81451,-3.05801 0.82166,-1.10031 2.25778,-1.10031 1.50757,0 2.30065,1.17176 l 0.0715,0 q -0.16433,-0.89311 -0.16433,-1.5933 l 0,-2.55787 2.18633,0 0,11.11743 -1.6719,0 -0.42155,-1.03601 -0.0929,0 q -0.74307,1.1789 -2.26492,1.1789 z m 0.7645,-1.7362 q 0.83595,0 1.22177,-0.48585 0.39297,-0.48585 0.42869,-1.65047 l 0,-0.23578 q 0,-1.28608 -0.40011,-1.84338 -0.39297,-0.5573 -1.28608,-0.5573 -0.72877,0 -1.13603,0.62161 -0.40012,0.61446 -0.40012,1.79336 0,1.1789 0.40726,1.77193 0.40726,0.58588 1.16462,0.58588 z"
+         style="font-weight:bold"
+         id="path5821"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 301.10959,664.71636 0,-1.08602 3.50814,0 0,1.08602 -3.50814,0 z"
+         style="font-weight:normal"
+         id="path5823"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 313.67743,668.09589 -1.21463,0 0,-9.36694 -3.30808,0 0,-1.07887 7.83078,0 0,1.07887 -3.30807,0 0,9.36694 z"
+         style="font-weight:normal"
+         id="path5825"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 323.73027,668.09589 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18605,0 0,-11.11743 1.18605,0 0,3.36524 q 0,0.60731 -0.0572,1.00742 l 0.0715,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32866 1.47899,-0.32866 1.43612,0 2.1506,0.6859 0.72164,0.67877 0.72164,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5827"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 328.53162,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5829"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 336.11234,665.95957 q 0,1.09316 -0.81452,1.68619 -0.81451,0.59302 -2.28636,0.59302 -1.55758,0 -2.42926,-0.49299 l 0,-1.10031 q 0.56445,0.28579 1.20749,0.45012 0.65018,0.16434 1.25035,0.16434 0.92884,0 1.42898,-0.29294 0.50014,-0.30009 0.50014,-0.9074 0,-0.45728 -0.40011,-0.77879 -0.39297,-0.32867 -1.5433,-0.77165 -1.09316,-0.40726 -1.55758,-0.70734 -0.45727,-0.30723 -0.68591,-0.69306 -0.22149,-0.38582 -0.22149,-0.92169 0,-0.95741 0.77879,-1.50756 0.77879,-0.5573 2.13632,-0.5573 1.26464,0 2.47213,0.51443 l -0.42155,0.96455 q -1.17891,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27179,0.26436 -0.42869,0.26436 -0.42869,0.72878 0,0.31438 0.15719,0.53587 0.16433,0.22149 0.52157,0.42154 0.35725,0.20006 1.37182,0.57874 1.39325,0.50729 1.8791,1.02172 0.493,0.51443 0.493,1.29322 z"
+         style="font-weight:normal"
+         id="path5831"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.65102,668.09589 -0.23578,-1.1146 -0.0571,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32894,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26464,-0.44299 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.49299 0.69305,-0.17862 1.38611,-0.17862 1.40039,0 2.07201,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67932,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-weight:normal"
+         id="path5833"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 353.55297,660.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95026,0 -1.62903,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5835"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 359.26173,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50786,-1.1146 1.47184,0 2.32922,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5837"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 368.97162,668.09589 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25721 -1.45041,0.25721 -1.16461,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35752 -0.39297,-0.44299 -1.26465,-0.44299 -0.97884,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.49299 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.6216 0.67876,0.6216 0.67876,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60732 0.63589,-0.60731 0.63589,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.62161,0.38583 -0.62161,1.20749 0,0.64304 0.38583,0.97885 0.39296,0.33581 1.09316,0.33581 z"
+         style="font-weight:normal"
+         id="path5839"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 382.49687,668.09589 -1.43612,-4.59416 q -0.13576,-0.42155 -0.50729,-1.91483 l -0.0572,0 q -0.28579,1.25036 -0.50014,1.92912 l -1.47899,4.57987 -1.37182,0 -2.13631,-7.83079 1.2432,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28608,0 1.40039,4.49413 q 0.40012,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15005,-0.79308 0.1286,-0.53587 1.49327,-5.76592 l 1.22892,0 -2.16489,7.83079 -1.40754,0 z"
+         style="font-weight:normal"
+         id="path5841"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.66289,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.493,0.19292 -0.30008,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5843"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 392.37822,668.09589 -1.18604,0 0,-11.11743 1.18604,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5845"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 396.09356,668.09589 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-weight:normal"
+         id="path5847"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.06781,660.1365 q 1.5433,0 2.39354,1.05744 0.85738,1.05029 0.85738,2.97941 0,1.92912 -0.86453,3.00085 -0.85738,1.06458 -2.38639,1.06458 -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 -0.25007,1.00743 -0.85024,0 0,-11.11743 1.18604,0 0,2.70076 q 0,0.9074 -0.0571,1.62903 l 0.0571,0 q 0.82881,-1.17175 2.45784,-1.17175 z m -0.17147,0.99313 q -1.21463,0 -1.7505,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65047 0.55016,2.36495 0.55016,0.70735 1.76478,0.70735 1.09317,0 1.62904,-0.79309 0.53586,-0.80022 0.53586,-2.2935 0,-1.529 -0.53586,-2.27922 -0.53587,-0.75021 -1.65761,-0.75021 z"
+         style="font-weight:normal"
+         id="path5849"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 414.70597,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.1932,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-weight:normal"
+         id="path5851"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 425.93057,667.25994 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.49299 0.50014,-1.67191 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-weight:normal"
+         id="path5853"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 432.1466,660.12221 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-weight:normal"
+         id="path5855"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.73333,668.09589 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20006,-0.59302 0.20005,-0.19291 0.50014,-0.19291 0.28579,0 0.49299,0.19291 0.20721,0.19291 0.20721,0.59302 0,0.40012 -0.20721,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50014,-0.19292 -0.20006,-0.20005 -0.20006,-0.60017 z"
+         style="font-weight:normal"
+         id="path5857"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 448.24402,668.09589 0,-5.0943 q 0,-0.93598 -0.40012,-1.4004 -0.40011,-0.47156 -1.24321,-0.47156 -1.10745,0 -1.63617,0.6359 -0.52872,0.63589 -0.52872,1.95769 l 0,4.37267 -1.18605,0 0,-5.0943 q 0,-0.93598 -0.40012,-1.4004 -0.40011,-0.47156 -1.25035,-0.47156 -1.1146,0 -1.63617,0.67162 -0.51444,0.66447 -0.51444,2.18633 l 0,4.10831 -1.18604,0 0,-7.83079 0.96455,0 0.19291,1.07173 0.0572,0 q 0.33581,-0.57159 0.94313,-0.89311 0.61446,-0.32151 1.37181,-0.32151 1.83624,0 2.40068,1.32894 l 0.0572,0 q 0.3501,-0.61446 1.01457,-0.9717 0.66448,-0.35724 1.51472,-0.35724 1.32894,0 1.98627,0.6859 0.66448,0.67877 0.66448,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5859"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.84785,668.09589 0,-5.0943 q 0,-0.93598 -0.40011,-1.4004 -0.40011,-0.47156 -1.24321,-0.47156 -1.10746,0 -1.63618,0.6359 -0.52872,0.63589 -0.52872,1.95769 l 0,4.37267 -1.18605,0 0,-5.0943 q 0,-0.93598 -0.40011,-1.4004 -0.40011,-0.47156 -1.25035,-0.47156 -1.1146,0 -1.63618,0.67162 -0.51443,0.66447 -0.51443,2.18633 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.33581,-0.57159 0.94312,-0.89311 0.61446,-0.32151 1.37182,-0.32151 1.83623,0 2.40068,1.32894 l 0.0572,0 q 0.3501,-0.61446 1.01457,-0.9717 0.66447,-0.35724 1.51471,-0.35724 1.32895,0 1.98628,0.6859 0.66447,0.67877 0.66447,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-weight:normal"
+         id="path5861"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 468.77837,668.23878 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-weight:normal"
+         id="path5863"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 479.00271,667.04559 -0.0643,0 q -0.82166,1.19319 -2.45784,1.19319 -1.53614,0 -2.39353,-1.05029 -0.85024,-1.0503 -0.85024,-2.98656 0,-1.93626 0.85739,-3.00799 0.85738,-1.07173 2.38638,-1.07173 1.59331,0 2.44355,1.15747 l 0.0929,0 -0.05,-0.56445 -0.0286,-0.55016 0,-3.18661 1.18605,0 0,11.11743 -0.96456,0 -0.15718,-1.0503 z m -2.3721,0.20006 q 1.21463,0 1.75764,-0.65733 0.55015,-0.66448 0.55015,-2.13632 l 0,-0.25007 q 0,-1.66476 -0.5573,-2.3721 -0.55015,-0.71449 -1.76478,-0.71449 -1.04315,0 -1.60045,0.81452 -0.55016,0.80737 -0.55016,2.28636 0,1.50042 0.55016,2.26492 0.55015,0.76451 1.61474,0.76451 z"
+         style="font-weight:normal"
+         id="path5865"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 493.20671,664.17335 q 0,1.91483 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.49299 -0.81452,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97941 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09316 0.97171,1.09317 0.97171,2.95798 z m -5.96598,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-weight:normal"
+         id="path5867"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 503.76683,661.18679 -1.99342,0 0,6.9091 -1.18604,0 0,-6.9091 -1.4004,0 0,-0.53586 1.4004,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.6216,0 1.45755,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32152,0.44298 -0.32152,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z m -4.95854,0 -1.99342,0 0,6.9091 -1.18605,0 0,-6.9091 -1.40039,0 0,-0.53586 1.40039,-0.4287 0,-0.43583 q 0,-2.88653 2.52214,-2.88653 0.62161,0 1.45756,0.25007 l -0.30723,0.95027 q -0.68591,-0.2215 -1.17176,-0.2215 -0.67162,0 -0.99314,0.45013 -0.32152,0.44298 -0.32152,1.42898 l 0,0.50728 1.99342,0 0,0.92169 z"
+         style="font-weight:normal"
+         id="path5869"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text8556">
+      <path
+         d="m 332.29654,748.41248 -2.515,-8.19518 -0.0643,0 q 0.13575,2.50071 0.13575,3.33666 l 0,4.85852 -1.97913,0 0,-10.44581 3.01514,0 2.47213,7.98797 0.0429,0 2.62217,-7.98797 3.01514,0 0,10.44581 -2.06487,0 0,-4.94426 q 0,-0.3501 0.007,-0.80737 0.0143,-0.45727 0.10003,-2.42926 l -0.0643,0 -2.69362,8.18089 -2.02914,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5788"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.57914,748.41248 -0.42154,-1.08603 -0.0572,0 q -0.55016,0.69306 -1.13604,0.96456 -0.57873,0.26436 -1.51471,0.26436 -1.15033,0 -1.8148,-0.65733 -0.65733,-0.65732 -0.65733,-1.87195 0,-1.27179 0.88597,-1.87196 0.89311,-0.60731 2.68647,-0.67162 l 1.38611,-0.0429 0,-0.3501 q 0,-1.21463 -1.24321,-1.21463 -0.95742,0 -2.25064,0.57874 l -0.72163,-1.47184 q 1.37896,-0.72164 3.05801,-0.72164 1.60759,0 2.46498,0.7002 0.85738,0.7002 0.85738,2.12917 l 0,5.32294 -1.52186,0 z m -0.64303,-3.70105 -0.8431,0.0286 q -0.95027,0.0286 -1.41468,0.34295 -0.46442,0.31438 -0.46442,0.95742 0,0.92169 1.05744,0.92169 0.75736,0 1.20748,-0.43584 0.45728,-0.43584 0.45728,-1.15747 l 0,-0.65733 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5790"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.4308,744.06839 0.95027,-1.21463 2.23634,-2.42926 2.45784,0 -3.17233,3.46527 3.36524,4.52271 -2.515,0 -2.30065,-3.23663 -0.93597,0.75021 0,2.48642 -2.17919,0 0,-11.11743 2.17919,0 0,4.95854 -0.11432,1.8148 0.0286,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5792"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 362.73371,741.8249 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40726,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92912,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00028,-3.10088 1.00743,-1.10031 2.77936,-1.10031 1.69333,0 2.63646,0.96456 0.94312,0.96456 0.94312,2.66504 l 0,1.05744 -5.15145,0 q 0.0357,0.92883 0.55015,1.45041 0.51443,0.52158 1.44327,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34323,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22177,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5794"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 377.4593,746.04038 q 0,1.22892 -0.85739,1.87195 -0.85024,0.64304 -2.55072,0.64304 -0.87167,0 -1.48613,-0.12146 -0.61446,-0.11432 -1.15033,-0.34295 l 0,-1.80051 q 0.60732,0.28579 1.36467,0.4787 0.76451,0.19292 1.34324,0.19292 1.18605,0 1.18605,-0.68591 0,-0.25722 -0.15719,-0.4144 -0.15718,-0.16434 -0.54301,-0.36439 -0.38582,-0.2072 -1.02886,-0.47871 -0.92169,-0.38582 -1.35753,-0.71449 -0.42869,-0.32866 -0.62875,-0.75021 -0.19291,-0.42869 -0.19291,-1.0503 0,-1.06458 0.82166,-1.64332 0.82881,-0.58588 2.34352,-0.58588 1.44327,0 2.80794,0.62875 l -0.65733,1.57187 q -0.60017,-0.25721 -1.12175,-0.42154 -0.52157,-0.16434 -1.06458,-0.16434 -0.96456,0 -0.96456,0.52158 0,0.29294 0.30723,0.50729 0.31437,0.21434 1.36467,0.63589 0.93598,0.37868 1.37182,0.70734 0.43583,0.32867 0.64304,0.75736 0.2072,0.42869 0.2072,1.02172 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5796"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 384.83281,748.41248 -0.29294,-1.02172 -0.11432,0 q -0.3501,0.5573 -0.99314,0.86453 -0.64304,0.30008 -1.4647,0.30008 -1.40754,0 -2.12202,-0.75021 -0.71449,-0.75736 -0.71449,-2.17204 l 0,-5.20862 2.17919,0 0,4.66561 q 0,0.86453 0.30723,1.30037 0.30722,0.42869 0.97884,0.42869 0.91455,0 1.3218,-0.60732 0.40726,-0.61446 0.40726,-2.02914 l 0,-3.75821 2.17919,0 0,7.98798 -1.6719,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5798"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 393.26376,740.27446 q 0.44298,0 0.73592,0.0643 l -0.16433,2.04343 q -0.26436,-0.0715 -0.64304,-0.0715 -1.04315,0 -1.62903,0.53587 -0.57873,0.53586 -0.57873,1.50042 l 0,4.06544 -2.17919,0 0,-7.98798 1.65046,0 0.32152,1.34324 0.10718,0 q 0.37153,-0.67162 1.00028,-1.07887 0.63589,-0.41441 1.37896,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5800"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 398.77246,741.8249 q -0.69305,0 -1.08602,0.44298 -0.39297,0.43584 -0.45013,1.24321 l 3.05801,0 q -0.0143,-0.80737 -0.42155,-1.24321 -0.40725,-0.44298 -1.10031,-0.44298 z m 0.30723,6.73047 q -1.92911,0 -3.01514,-1.06458 -1.08602,-1.06459 -1.08602,-3.01514 0,-2.00771 1.00029,-3.10088 1.00742,-1.10031 2.77935,-1.10031 1.69334,0 2.63646,0.96456 0.94313,0.96456 0.94313,2.66504 l 0,1.05744 -5.15146,0 q 0.0357,0.92883 0.55016,1.45041 0.51443,0.52158 1.44326,0.52158 0.72163,0 1.36467,-0.15005 0.64304,-0.15004 1.34324,-0.4787 l 0,1.68619 q -0.57159,0.28579 -1.22178,0.42155 -0.65018,0.14289 -1.58616,0.14289 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5802"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 406.78187,740.4245 2.38639,0 1.50757,4.49413 q 0.19291,0.58588 0.26436,1.38611 l 0.0429,0 q 0.0786,-0.73592 0.30723,-1.38611 l 1.47899,-4.49413 2.33638,0 -3.37953,9.00969 q -0.46442,1.25036 -1.32895,1.87196 -0.85738,0.6216 -2.00771,0.6216 -0.56444,0 -1.10745,-0.12146 l 0,-1.72906 q 0.39297,0.0929 0.85738,0.0929 0.57874,0 1.00743,-0.35724 0.43584,-0.3501 0.67876,-1.06459 l 0.12861,-0.39296 -3.17232,-7.93082 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5804"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 417.97789,744.4042 q 0,1.18605 0.38582,1.79336 0.39297,0.60732 1.27179,0.60732 0.87167,0 1.25035,-0.60017 0.38583,-0.60732 0.38583,-1.80051 0,-1.18605 -0.38583,-1.77907 -0.38582,-0.59303 -1.26464,-0.59303 -0.87168,0 -1.2575,0.59303 -0.38582,0.58588 -0.38582,1.77907 z m 5.52299,0 q 0,1.95055 -1.02887,3.05086 -1.02886,1.10031 -2.86509,1.10031 -1.15033,0 -2.02915,-0.50014 -0.87881,-0.50728 -1.35038,-1.45041 -0.47156,-0.94312 -0.47156,-2.20062 0,-1.9577 1.02172,-3.04372 1.02172,-1.08602 2.87224,-1.08602 1.15032,0 2.02914,0.50014 0.87882,0.50015 1.35038,1.43612 0.47157,0.93598 0.47157,2.19348 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5806"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 430.96012,748.41248 -0.29294,-1.02172 -0.11431,0 q -0.3501,0.5573 -0.99314,0.86453 -0.64304,0.30008 -1.4647,0.30008 -1.40754,0 -2.12203,-0.75021 -0.71449,-0.75736 -0.71449,-2.17204 l 0,-5.20862 2.17919,0 0,4.66561 q 0,0.86453 0.30723,1.30037 0.30723,0.42869 0.97885,0.42869 0.91454,0 1.3218,-0.60732 0.40726,-0.61446 0.40726,-2.02914 l 0,-3.75821 2.17919,0 0,7.98798 -1.67191,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5808"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 434.62545,747.39076 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32866,0.32152 -0.91454,0.32152 -0.60017,0 -0.92884,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z m 0,-5.90167 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31438 0.32866,0.31437 0.32866,0.90025 0,0.57874 -0.3358,0.90026 -0.32867,0.31437 -0.9074,0.31437 -0.60017,0 -0.92884,-0.31437 -0.32866,-0.31438 -0.32866,-0.90026 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5810"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:150%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="176.30603"
-       y="788.41248"
-       id="text8562"
-       sodipodi:linespacing="150%"><tspan
-         sodipodi:role="line"
-         id="tspan8564"
-         x="176.30603"
-         y="788.41248"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
-   style="font-weight:bold;line-height:150%"
-   id="tspan8572">1.</tspan> Put your artwork in the &quot;Artwork&quot; layer.</tspan><tspan
-         sodipodi:role="line"
-         x="176.30603"
-         y="810.36151"
+       id="text8562">
+      <path
+         d="m 182.35059,788.41248 -2.20776,0 0,-6.04457 0.0214,-0.99314 0.0357,-1.08602 q -0.55016,0.55016 -0.7645,0.72163 l -1.20034,0.96456 -1.06459,-1.32894 3.36524,-2.67933 1.81479,0 0,10.44581 z"
+         style="font-weight:bold;line-height:150%"
+         id="path5609"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 185.4872,787.39076 q 0,-0.60017 0.32151,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59303,0 0.91455,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32867,0.32152 -0.91455,0.32152 -0.60017,0 -0.92883,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-weight:bold;line-height:150%"
+         id="path5611"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 200.68435,781.01038 q 0,1.58617 -1.08603,2.44355 -1.07887,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.10831 -1.21462,0 0,-10.44581 2.7079,0 q 3.9154,0 3.9154,3.04371 z m -5.40868,2.25064 1.09317,0 q 1.61474,0 2.33637,-0.52158 0.72164,-0.52157 0.72164,-1.6719 0,-1.036 -0.67877,-1.54329 -0.67876,-0.50729 -2.11488,-0.50729 l -1.35753,0 0,4.24406 z"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
-         id="tspan8568"><tspan
-   style="font-weight:bold;line-height:150%"
-   id="tspan8574">2.</tspan> Outline your text. (Select text, then Paths &gt; Object to Path) </tspan></text>
+         id="path5613"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.79951,780.58169 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47157 1.36467,0.47157 1.22892,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17147,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47184,0.30723 -1.42898,0 -2.14347,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5615"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 214.18816,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5617"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 219.38963,780.58169 1.27179,0 1.71477,4.46555 q 0.56444,1.529 0.70019,2.20777 l 0.0572,0 q 0.0929,-0.36439 0.38583,-1.24321 0.30008,-0.88597 1.9434,-5.43011 l 1.27179,0 -3.36524,8.91681 q -0.50014,1.3218 -1.17175,1.87195 -0.66448,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22177,0 1.74335,-1.37181 l 0.43583,-1.11461 -3.15803,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5619"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 234.7654,784.48994 q 0,1.91483 -0.96456,2.9937 -0.96455,1.07173 -2.66503,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.2575,-1.41469 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76478,0.78594 1.16462,0 1.76479,-0.7788 0.60731,-0.78593 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75763,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5621"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 237.95202,780.58169 0,5.08001 q 0,0.95741 0.43583,1.42897 0.43584,0.47157 1.36468,0.47157 1.22891,0 1.79336,-0.67162 0.57159,-0.67162 0.57159,-2.19348 l 0,-4.11545 1.18605,0 0,7.83079 -0.97885,0 -0.17148,-1.0503 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47185,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70734,-0.67876 -0.70734,-2.17204 l 0,-5.12288 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5623"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 249.38381,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5625"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 260.40122,788.41248 -0.23579,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40012,-1.35753 -0.39297,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.49299 0.69306,-0.17863 1.38611,-0.17863 1.40039,0 2.07201,0.62161 0.67877,0.6216 0.67877,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5627"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 267.30316,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5629"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 272.23313,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5631"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 281.27139,788.41248 -1.43612,-4.59416 q -0.13575,-0.42155 -0.50728,-1.91483 l -0.0572,0 q -0.2858,1.25036 -0.50014,1.92912 l -1.47899,4.57987 -1.37182,0 -2.13632,-7.83079 1.24321,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28608,0 1.40039,4.49413 q 0.40011,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15004,-0.79308 0.12861,-0.53587 1.49328,-5.76592 l 1.22892,0 -2.1649,7.83079 -1.40754,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5633"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 293.01042,784.48994 q 0,1.91483 -0.96455,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.25749,-1.41469 -0.44299,-0.92169 -0.44299,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5635"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 298.65488,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48586,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5637"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 302.22732,784.4042 q 0.30722,-0.43584 0.93597,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17232,3.33666 3.39381,4.49413 -1.43612,0 -2.76507,-3.70105 -0.8931,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5639"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 313.73057,788.41248 -1.18605,0 0,-7.83079 1.18605,0 0,7.83079 z m -1.28608,-9.95282 q 0,-0.40725 0.20005,-0.59302 0.20006,-0.19291 0.50015,-0.19291 0.28579,0 0.49299,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40012 -0.2072,0.60017 -0.2072,0.19292 -0.49299,0.19292 -0.30009,0 -0.50015,-0.19292 -0.20005,-0.20005 -0.20005,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5641"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 321.6185,788.41248 0,-5.06572 q 0,-0.95741 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66448 -0.57159,0.66447 -0.57159,2.19347 l 0,4.10831 -1.18605,0 0,-7.83079 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67877 0.71448,2.17919 l 0,5.10859 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5643"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 331.56417,787.57653 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.3358,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5645"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 339.56644,788.41248 0,-5.06572 q 0,-0.95741 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09402 -1.18605,0 0,-11.11743 1.18605,0 0,3.36524 q 0,0.60731 -0.0571,1.00742 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65019,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67877 0.72163,2.1649 l 0,5.10859 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5647"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 346.48982,788.55537 q -1.73621,0 -2.74364,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.11461 2.50786,-1.11461 1.47184,0 2.32923,0.97171 0.85738,0.96456 0.85738,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66448,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5649"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 356.20684,777.96667 -0.28579,3.77249 -0.75021,0 -0.29294,-3.77249 1.32894,0 z m 2.63646,0 -0.29294,3.77249 -0.74307,0 -0.29294,-3.77249 1.32895,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5651"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 367.7887,788.41248 -1.30037,-3.32237 -4.1869,0 -1.28607,3.32237 -1.22892,0 4.12974,-10.48868 1.02171,0 4.10831,10.48868 -1.2575,0 z m -1.67905,-4.41554 -1.21463,-3.23663 q -0.23578,-0.61446 -0.48585,-1.50756 -0.15718,0.6859 -0.45012,1.50756 l -1.22892,3.23663 3.37952,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5653"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.87612,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62904,0.77165 -0.67161,0.77164 -0.67161,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97884,0 0.13576,1.45041 0.0572,0 q 0.43583,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5655"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 378.80609,787.57653 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15004 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60845 q 0,0.70734 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5657"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 387.84436,788.41248 -1.43612,-4.59416 q -0.13575,-0.42155 -0.50728,-1.91483 l -0.0572,0 q -0.2858,1.25036 -0.50015,1.92912 l -1.47898,4.57987 -1.37182,0 -2.13632,-7.83079 1.24321,0 q 0.75736,2.95084 1.15033,4.49413 0.40011,1.54329 0.45727,2.07916 l 0.0572,0 q 0.0786,-0.40726 0.25007,-1.0503 0.17862,-0.65018 0.30723,-1.02886 l 1.43612,-4.49413 1.28607,0 1.4004,4.49413 q 0.40011,1.22892 0.54301,2.06487 l 0.0572,0 q 0.0286,-0.25722 0.15004,-0.79308 0.12861,-0.53587 1.49328,-5.76592 l 1.22892,0 -2.1649,7.83079 -1.40754,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5659"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 399.58338,784.48994 q 0,1.91483 -0.96455,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86482,-0.49299 -0.81451,-0.493 -1.25749,-1.41469 -0.44299,-0.92169 -0.44299,-2.15775 0,-1.91483 0.95742,-2.97941 0.95741,-1.07174 2.65789,-1.07174 1.64332,0 2.60788,1.09317 0.9717,1.09317 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78594 1.76479,0.78594 1.16461,0 1.76478,-0.7788 0.60732,-0.78593 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.76451 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5661"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 405.22784,780.43879 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48586,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.1789 0.61446,-0.41441 1.35038,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5663"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 408.80028,784.4042 q 0.30722,-0.43584 0.93597,-1.14318 l 2.52929,-2.67933 1.40754,0 -3.17232,3.33666 3.39381,4.49413 -1.43612,0 -2.76507,-3.70105 -0.8931,0.77165 0,2.9294 -1.17176,0 0,-11.11743 1.17176,0 0,5.89452 q 0,0.39297 -0.0572,1.21463 l 0.0572,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5665"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 416.33811,777.96667 -0.28579,3.77249 -0.75021,0 -0.29294,-3.77249 1.32894,0 z m 2.63646,0 -0.29294,3.77249 -0.74306,0 -0.29294,-3.77249 1.32894,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5667"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.16233,788.41248 -1.18605,0 0,-11.11743 1.18605,0 0,11.11743 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5669"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 433.50726,788.41248 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25721 -1.45041,0.25721 -1.16462,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40012,-1.35753 -0.39296,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26464,-0.49299 0.69306,-0.17863 1.38611,-0.17863 1.40039,0 2.07201,0.62161 0.67877,0.6216 0.67877,1.99342 l 0,5.34437 -0.87882,0 z m -2.67933,-0.83595 q 1.10745,0 1.7362,-0.60732 0.6359,-0.60731 0.6359,-1.70048 l 0,-0.70734 -1.18605,0.05 q -1.41469,0.05 -2.04344,0.44298 -0.6216,0.38583 -0.6216,1.20749 0,0.64304 0.38582,0.97885 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5671"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 435.59357,780.58169 1.27179,0 1.71477,4.46555 q 0.56445,1.529 0.7002,2.20777 l 0.0572,0 q 0.0929,-0.36439 0.38582,-1.24321 0.30009,-0.88597 1.94341,-5.43011 l 1.27179,0 -3.36524,8.91681 q -0.50014,1.3218 -1.17176,1.87195 -0.66447,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22178,0 1.74335,-1.37181 l 0.43584,-1.11461 -3.15804,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5673"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 447.51836,788.55537 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93654 0,-1.89339 0.92883,-3.00799 0.93598,-1.11461 2.50786,-1.11461 1.47184,0 2.32922,0.97171 0.85739,0.96456 0.85739,2.55072 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71449 1.86481,0.71449 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.2715 -1.19319,0.38582 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12174 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5675"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 455.98503,780.43879 q 0.52157,0 0.93597,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85738,-0.10717 -0.95027,0 -1.62903,0.77165 -0.67162,0.77164 -0.67162,1.92197 l 0,4.20119 -1.18605,0 0,-7.83079 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.05029,-1.1789 0.61446,-0.41441 1.35039,-0.41441 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5677"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 458.21423,787.65512 q 0,-0.47871 0.21434,-0.72163 0.22149,-0.25007 0.62875,-0.25007 0.4144,0 0.64304,0.25007 0.23578,0.24292 0.23578,0.72163 0,0.46442 -0.23578,0.71449 -0.23578,0.25007 -0.64304,0.25007 -0.36439,0 -0.60731,-0.22149 -0.23578,-0.22864 -0.23578,-0.74307 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5679"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 184.19397,810.36153 -7.30206,0 0,-1.53615 2.62217,-2.65074 q 1.16461,-1.1932 1.52186,-1.65047 0.35724,-0.46442 0.51443,-0.85739 0.15719,-0.39296 0.15719,-0.81451 0,-0.62875 -0.3501,-0.93598 -0.34296,-0.30723 -0.92169,-0.30723 -0.60732,0 -1.17891,0.27865 -0.57159,0.27865 -1.19319,0.79308 l -1.20034,-1.42183 q 0.77165,-0.65733 1.27893,-0.92883 0.50729,-0.27151 1.10746,-0.41441 0.60017,-0.15004 1.34324,-0.15004 0.97884,0 1.72906,0.35725 0.75021,0.35724 1.16461,1.00028 0.4144,0.64304 0.4144,1.47184 0,0.72164 -0.25721,1.35753 -0.25007,0.62875 -0.78594,1.29322 -0.52872,0.66448 -1.87196,1.89339 l -1.34323,1.26465 0,0.10003 4.55128,0 0,1.85766 z"
+         style="font-weight:bold;line-height:150%"
+         id="path5681"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 185.4872,809.33982 q 0,-0.60017 0.32151,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59303,0 0.91455,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.8931 -0.32867,0.32152 -0.91455,0.32152 -0.60017,0 -0.92883,-0.31437 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-weight:bold;line-height:150%"
+         id="path5683"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 203.12789,805.12434 q 0,2.50785 -1.27179,3.94397 -1.26464,1.43612 -3.52242,1.43612 -2.30779,0 -3.56529,-1.40754 -1.25035,-1.41469 -1.25035,-3.98684 0,-2.55072 1.25749,-3.95112 1.2575,-1.40754 3.57244,-1.40754 2.25064,0 3.51528,1.42898 1.26464,1.42897 1.26464,3.94397 z m -8.32378,0 q 0,2.12203 0.90026,3.22234 0.9074,1.09316 2.62931,1.09316 1.73621,0 2.62217,-1.09316 0.88596,-1.09317 0.88596,-3.22234 0,-2.10774 -0.88596,-3.19376 -0.87882,-1.09317 -2.60788,-1.09317 -1.7362,0 -2.6436,1.10031 -0.90026,1.09317 -0.90026,3.18662 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5685"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 206.40025,802.53075 0,5.08001 q 0,0.95741 0.43583,1.42897 0.43584,0.47156 1.36467,0.47156 1.22892,0 1.79337,-0.67162 0.57159,-0.67161 0.57159,-2.19347 l 0,-4.11545 1.18605,0 0,7.83078 -0.97885,0 -0.17148,-1.05029 -0.0643,0 q -0.36439,0.57873 -1.01457,0.88596 -0.64304,0.30723 -1.47185,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70734,-0.67877 -0.70734,-2.17205 l 0,-5.12287 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5687"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 216.78889,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.3358,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5689"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 220.61855,810.36153 -1.18605,0 0,-11.11742 1.18605,0 0,11.11742 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5691"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 224.33388,810.36153 -1.18605,0 0,-7.83078 1.18605,0 0,7.83078 z m -1.28608,-9.95281 q 0,-0.40726 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40011 -0.2072,0.60017 -0.2072,0.19291 -0.493,0.19291 -0.30008,0 -0.50014,-0.19291 -0.20006,-0.20006 -0.20006,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5693"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 232.22183,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66447 -0.57159,0.66448 -0.57159,2.19348 l 0,4.1083 -1.18605,0 0,-7.83078 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67876 0.71448,2.17919 l 0,5.10858 -1.18604,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5695"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 239.14521,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39439,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5697"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 246.59731,802.53075 1.27179,0 1.71477,4.46555 q 0.56445,1.529 0.7002,2.20776 l 0.0572,0 q 0.0929,-0.36439 0.38582,-1.24321 0.30009,-0.88596 1.94341,-5.4301 l 1.27178,0 -3.36523,8.9168 q -0.50014,1.32181 -1.17176,1.87196 -0.66447,0.5573 -1.63618,0.5573 -0.54301,0 -1.07173,-0.12146 l 0,-0.95027 q 0.39297,0.0857 0.87882,0.0857 1.22177,0 1.74335,-1.37182 l 0.43584,-1.1146 -3.15804,-7.87365 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5699"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 261.97309,806.439 q 0,1.91482 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.493 -0.81452,-0.49299 -1.2575,-1.41468 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97942 0.95741,-1.07173 2.65789,-1.07173 1.64332,0 2.60788,1.09317 0.97171,1.09316 0.97171,2.95798 z m -5.96598,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78593 1.76479,0.78593 1.16461,0 1.76478,-0.77879 0.60732,-0.78594 0.60732,-2.2935 0,-1.49328 -0.60732,-2.26493 -0.60017,-0.77879 -1.77907,-0.77879 -1.16462,0 -1.75764,0.7645 -0.59303,0.7645 -0.59303,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5701"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 265.1597,802.53075 0,5.08001 q 0,0.95741 0.43584,1.42897 0.43584,0.47156 1.36467,0.47156 1.22892,0 1.79337,-0.67162 0.57159,-0.67161 0.57159,-2.19347 l 0,-4.11545 1.18605,0 0,7.83078 -0.97885,0 -0.17148,-1.05029 -0.0643,0 q -0.36439,0.57873 -1.01458,0.88596 -0.64303,0.30723 -1.47184,0.30723 -1.42897,0 -2.14346,-0.67876 -0.70735,-0.67877 -0.70735,-2.17205 l 0,-5.12287 1.20034,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5703"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 276.5915,802.38785 q 0.52158,0 0.93598,0.0857 l -0.16433,1.10031 q -0.48585,-0.10717 -0.85739,-0.10717 -0.95027,0 -1.62903,0.77164 -0.67162,0.77165 -0.67162,1.92198 l 0,4.20118 -1.18605,0 0,-7.83078 0.97885,0 0.13575,1.45041 0.0572,0 q 0.43584,-0.7645 1.0503,-1.17891 0.61446,-0.4144 1.35038,-0.4144 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5705"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 285.32254,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.6859,0 0,1.8148 2.27208,0 0,0.92169 -2.27208,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5707"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 291.27422,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35039,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5709"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 298.05471,806.35326 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05773,-3.00085 1.33609,0 -2.7222,3.82251 2.8651,4.00827 -1.34324,0 -2.19348,-3.17232 -2.21491,3.17232 -1.34323,0 2.86509,-4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5711"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 306.35705,809.52558 q 0.31438,0 0.60732,-0.0429 0.29293,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5713"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 308.82919,809.60418 q 0,-0.47871 0.21434,-0.72164 0.22149,-0.25007 0.62875,-0.25007 0.4144,0 0.64304,0.25007 0.23578,0.24293 0.23578,0.72164 0,0.46441 -0.23578,0.71448 -0.23578,0.25007 -0.64304,0.25007 -0.36439,0 -0.60731,-0.22149 -0.23578,-0.22863 -0.23578,-0.74306 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5715"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 316.01693,806.35326 q 0,-1.89339 0.55015,-3.54386 0.5573,-1.65047 1.60045,-2.89368 l 1.15747,0 q -1.02886,1.37897 -1.55044,3.02943 -0.51443,1.65047 -0.51443,3.39382 0,1.71477 0.52872,3.35094 0.52873,1.63618 1.52186,2.98656 l -1.14318,0 q -1.05029,-1.21463 -1.60045,-2.83651 -0.55015,-1.62189 -0.55015,-3.4867 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5717"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 327.10577,807.58218 q 0,1.37896 -1.00028,2.1506 -1.00028,0.77165 -2.71505,0.77165 -1.85767,0 -2.85795,-0.47871 l 0,-1.17176 q 0.64304,0.27151 1.40039,0.4287 0.75736,0.15718 1.50043,0.15718 1.21463,0 1.82909,-0.45727 0.61445,-0.46442 0.61445,-1.28608 0,-0.54301 -0.22149,-0.88596 -0.21434,-0.3501 -0.72877,-0.64304 -0.50729,-0.29294 -1.55044,-0.66447 -1.45756,-0.52158 -2.08631,-1.23607 -0.6216,-0.71448 -0.6216,-1.86481 0,-1.20748 0.9074,-1.92197 0.9074,-0.71449 2.40068,-0.71449 1.55758,0 2.86509,0.57159 l -0.37868,1.05744 q -1.29322,-0.54301 -2.51499,-0.54301 -0.96456,0 -1.50757,0.41441 -0.54301,0.4144 -0.54301,1.15032 0,0.54301 0.20006,0.89311 0.20005,0.34295 0.67161,0.63589 0.47871,0.2858 1.45756,0.6359 1.64332,0.58588 2.25778,1.2575 0.6216,0.67161 0.6216,1.74335 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5719"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 332.37154,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35039,0.12146 z m -0.32151,-7.12344 q -0.94313,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5721"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 338.45183,810.36153 -1.18605,0 0,-11.11742 1.18605,0 0,11.11742 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5723"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 344.28919,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65732,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5725"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 352.31289,810.50443 q -1.70048,0 -2.63646,-1.04315 -0.92884,-1.0503 -0.92884,-2.96512 0,-1.96485 0.94313,-3.03658 0.95027,-1.07173 2.70076,-1.07173 0.56445,0 1.12889,0.12146 0.56445,0.12147 0.88597,0.2858 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85739,-0.25722 -0.46441,-0.10717 -0.82166,-0.10717 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57874,2.21491 0.58588,0.77164 1.72906,0.77164 0.97885,0 2.00771,-0.42154 l 0,1.05029 q -0.78594,0.40726 -1.97913,0.40726 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5727"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 358.68612,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5729"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 367.66009,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5731"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 373.61176,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26465,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.19319,0.38583 -0.55731,0.12146 -1.35039,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50756,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5733"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 380.39225,806.35326 -2.7222,-3.82251 1.35038,0 2.06487,3.00085 2.05773,-3.00085 1.33609,0 -2.7222,3.82251 2.8651,4.00827 -1.34324,0 -2.19348,-3.17232 -2.21491,3.17232 -1.34324,0 2.8651,-4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5735"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 388.69461,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5737"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 392.58141,808.66105 0.10717,0.16433 q -0.18576,0.71449 -0.53586,1.65762 -0.3501,0.95026 -0.72878,1.76478 l -0.89311,0 q 0.19291,-0.74307 0.42155,-1.83623 0.23578,-1.09317 0.32866,-1.7505 l 1.30037,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5739"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 401.26957,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67161,0.0643 -2.27208,0 -2.27208,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5741"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 409.27184,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43583,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0714,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67876 0.72163,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5743"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 416.19523,810.50443 q -1.73621,0 -2.74363,-1.05744 -1.00029,-1.05744 -1.00029,-2.93655 0,-1.89339 0.92884,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47184,0 2.32923,0.9717 0.85738,0.96456 0.85738,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69306,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.5007,-0.52872 l 0,1.05744 q -0.62874,0.27151 -1.19319,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65733,1.70048 l 4.09402,0 q 0,-1.12175 -0.50015,-1.71477 -0.50014,-0.60017 -1.42897,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5745"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 426.44812,810.36153 0,-5.06571 q 0,-0.95742 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.22892,0 -1.80051,0.66447 -0.57159,0.66448 -0.57159,2.19348 l 0,4.1083 -1.18605,0 0,-7.83078 0.96456,0 0.19291,1.07173 0.0572,0 q 0.36439,-0.57873 1.02171,-0.89311 0.65733,-0.32152 1.4647,-0.32152 1.41469,0 2.12918,0.68591 0.71448,0.67876 0.71448,2.17919 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5747"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 440.66641,802.95944 q 0,1.58616 -1.08602,2.44355 -1.07887,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.1083 -1.21463,0 0,-10.44581 2.70791,0 q 3.91539,0 3.91539,3.04372 z m -5.40867,2.25064 1.09317,0 q 1.61474,0 2.33637,-0.52158 0.72164,-0.52157 0.72164,-1.6719 0,-1.03601 -0.67877,-1.54329 -0.67876,-0.50729 -2.11488,-0.50729 l -1.35753,0 0,4.24406 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5749"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 447.48263,810.36153 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57874,0.25722 -1.45041,0.25722 -1.16461,0 -1.82909,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32895,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35753 -0.39297,-0.44298 -1.26465,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57874,-0.31437 1.26465,-0.493 0.69305,-0.17862 1.3861,-0.17862 1.4004,0 2.07202,0.62161 0.67876,0.6216 0.67876,1.99342 l 0,5.34436 -0.87882,0 z m -2.67933,-0.83595 q 1.10746,0 1.73621,-0.60731 0.63589,-0.60732 0.63589,-1.70048 l 0,-0.70735 -1.18605,0.05 q -1.41469,0.05 -2.04343,0.44298 -0.62161,0.38582 -0.62161,1.20749 0,0.64303 0.38582,0.97884 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5751"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 453.34144,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5753"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.34369,810.36153 0,-5.06571 q 0,-0.95742 -0.43583,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23607,0 -1.80766,0.67162 -0.56444,0.67162 -0.56444,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0715,0 q 0.3501,-0.56444 0.99313,-0.88596 0.65019,-0.32867 1.47899,-0.32867 1.43612,0 2.15061,0.68591 0.72163,0.67876 0.72163,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5755"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 470.01043,808.22521 q 0,1.09317 -0.81451,1.6862 -0.81452,0.59302 -2.28636,0.59302 -1.55759,0 -2.42926,-0.493 l 0,-1.10031 q 0.56444,0.2858 1.20748,0.45013 0.65019,0.16433 1.25036,0.16433 0.92883,0 1.42897,-0.29294 0.50014,-0.30008 0.50014,-0.9074 0,-0.45727 -0.40011,-0.77879 -0.39297,-0.32866 -1.54329,-0.77164 -1.09317,-0.40726 -1.55759,-0.70735 -0.45727,-0.30723 -0.6859,-0.69305 -0.2215,-0.38582 -0.2215,-0.92169 0,-0.95741 0.7788,-1.50757 0.77879,-0.5573 2.13631,-0.5573 1.26465,0 2.47213,0.51443 l -0.42155,0.96456 q -1.1789,-0.48585 -2.13632,-0.48585 -0.84309,0 -1.27178,0.26436 -0.4287,0.26436 -0.4287,0.72878 0,0.31437 0.15719,0.53586 0.16433,0.22149 0.52158,0.42155 0.35724,0.20006 1.37181,0.57874 1.39325,0.50728 1.87911,1.02171 0.49299,0.51443 0.49299,1.29322 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5757"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 475.21905,807.5536 5.59444,-2.32923 -5.59444,-2.66504 0,-1.06459 6.86622,3.4224 0,0.7002 -6.86622,3.01513 0,-1.07887 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5759"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 497.15382,805.12434 q 0,2.50785 -1.27179,3.94397 -1.26465,1.43612 -3.52243,1.43612 -2.30779,0 -3.56529,-1.40754 -1.25035,-1.41469 -1.25035,-3.98684 0,-2.55072 1.2575,-3.95112 1.25749,-1.40754 3.57243,-1.40754 2.25064,0 3.51528,1.42898 1.26465,1.42897 1.26465,3.94397 z m -8.32378,0 q 0,2.12203 0.90025,3.22234 0.9074,1.09316 2.62931,1.09316 1.73621,0 2.62217,-1.09316 0.88597,-1.09317 0.88597,-3.22234 0,-2.10774 -0.88597,-3.19376 -0.87882,-1.09317 -2.60788,-1.09317 -1.7362,0 -2.6436,1.10031 -0.90025,1.09317 -0.90025,3.18662 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5761"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 502.95546,802.40214 q 1.54329,0 2.39353,1.05744 0.85739,1.0503 0.85739,2.97942 0,1.92911 -0.86453,3.00084 -0.85739,1.06459 -2.38639,1.06459 -0.7645,0 -1.40039,-0.27865 -0.62875,-0.28579 -1.05745,-0.87167 l -0.0857,0 -0.25007,1.00742 -0.85024,0 0,-11.11742 1.18604,0 0,2.70076 q 0,0.9074 -0.0571,1.62903 l 0.0571,0 q 0.82881,-1.17176 2.45784,-1.17176 z m -0.17148,0.99314 q -1.21462,0 -1.75049,0.7002 -0.53587,0.69305 -0.53587,2.34352 0,1.65046 0.55016,2.36495 0.55016,0.70734 1.76478,0.70734 1.09317,0 1.62904,-0.79308 0.53586,-0.80022 0.53586,-2.2935 0,-1.52901 -0.53586,-2.27922 -0.53587,-0.75021 -1.65762,-0.75021 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5763"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 507.33524,813.87681 q -0.67876,0 -1.10031,-0.17862 l 0,-0.96456 q 0.493,0.1429 0.97171,0.1429 0.5573,0 0.81451,-0.30723 0.26436,-0.30009 0.26436,-0.92169 l 0,-9.11686 1.18605,0 0,9.03112 q 0,2.31494 -2.13632,2.31494 z m 0.85024,-13.46809 q 0,-0.40726 0.20006,-0.59302 0.20006,-0.19291 0.50014,-0.19291 0.2858,0 0.493,0.19291 0.2072,0.19291 0.2072,0.59302 0,0.40011 -0.2072,0.60017 -0.2072,0.19291 -0.493,0.19291 -0.30008,0 -0.50014,-0.19291 -0.20006,-0.20006 -0.20006,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5765"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 515.30892,810.50443 q -1.7362,0 -2.74363,-1.05744 -1.00028,-1.05744 -1.00028,-2.93655 0,-1.89339 0.92883,-3.00799 0.93598,-1.1146 2.50785,-1.1146 1.47185,0 2.32923,0.9717 0.85739,0.96456 0.85739,2.55073 l 0,0.75021 -5.39438,0 q 0.0357,1.37896 0.69305,2.09345 0.66447,0.71448 1.86481,0.71448 1.26464,0 2.50071,-0.52872 l 0,1.05744 q -0.62875,0.27151 -1.1932,0.38583 -0.5573,0.12146 -1.35038,0.12146 z m -0.32152,-7.12344 q -0.94312,0 -1.50757,0.61446 -0.5573,0.61446 -0.65732,1.70048 l 4.09401,0 q 0,-1.12175 -0.50014,-1.71477 -0.50014,-0.60017 -1.42898,-0.60017 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5767"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 523.33263,810.50443 q -1.70048,0 -2.63646,-1.04315 -0.92883,-1.0503 -0.92883,-2.96512 0,-1.96485 0.94312,-3.03658 0.95027,-1.07173 2.70077,-1.07173 0.56444,0 1.12889,0.12146 0.56444,0.12147 0.88596,0.2858 l -0.36439,1.00743 q -0.39297,-0.15719 -0.85738,-0.25722 -0.46442,-0.10717 -0.82166,-0.10717 -2.38639,0 -2.38639,3.04372 0,1.44326 0.57873,2.21491 0.58588,0.77164 1.72906,0.77164 0.97885,0 2.00771,-0.42154 l 0,1.05029 q -0.78593,0.40726 -1.97913,0.40726 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5769"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 529.70585,809.52558 q 0.31438,0 0.60732,-0.0429 0.29294,-0.05 0.46441,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50015,-1.6719 0.6859,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5771"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 538.67982,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37153,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12174,0 0,-0.57159 1.12174,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5773"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 548.08247,806.439 q 0,1.91482 -0.96456,2.9937 -0.96456,1.07173 -2.66504,1.07173 -1.0503,0 -1.86481,-0.493 -0.81452,-0.49299 -1.2575,-1.41468 -0.44298,-0.92169 -0.44298,-2.15775 0,-1.91483 0.95741,-2.97942 0.95742,-1.07173 2.6579,-1.07173 1.64332,0 2.60788,1.09317 0.9717,1.09316 0.9717,2.95798 z m -5.96597,0 q 0,1.50042 0.60017,2.28636 0.60017,0.78593 1.76478,0.78593 1.16462,0 1.76479,-0.77879 0.60731,-0.78594 0.60731,-2.2935 0,-1.49328 -0.60731,-2.26493 -0.60017,-0.77879 -1.77908,-0.77879 -1.16461,0 -1.75764,0.7645 -0.59302,0.7645 -0.59302,2.27922 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5775"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 560.75748,802.95944 q 0,1.58616 -1.08602,2.44355 -1.07888,0.85024 -3.09373,0.85024 l -1.22892,0 0,4.1083 -1.21463,0 0,-10.44581 2.70791,0 q 3.91539,0 3.91539,3.04372 z m -5.40867,2.25064 1.09316,0 q 1.61475,0 2.33638,-0.52158 0.72163,-0.52157 0.72163,-1.6719 0,-1.03601 -0.67876,-1.54329 -0.67877,-0.50729 -2.11489,-0.50729 l -1.35752,0 0,4.24406 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5777"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 567.57369,810.36153 -0.23578,-1.1146 -0.0572,0 q -0.58588,0.73592 -1.17176,1.00028 -0.57873,0.25722 -1.45041,0.25722 -1.16461,0 -1.82908,-0.60017 -0.65733,-0.60017 -0.65733,-1.70762 0,-2.3721 3.79393,-2.48642 l 1.32894,-0.0429 0,-0.48585 q 0,-0.92169 -0.40011,-1.35753 -0.39297,-0.44298 -1.26464,-0.44298 -0.97885,0 -2.21491,0.60017 l -0.36439,-0.9074 q 0.57873,-0.31437 1.26464,-0.493 0.69305,-0.17862 1.38611,-0.17862 1.40039,0 2.07201,0.62161 0.67876,0.6216 0.67876,1.99342 l 0,5.34436 -0.87882,0 z m -2.67932,-0.83595 q 1.10745,0 1.7362,-0.60731 0.63589,-0.60732 0.63589,-1.70048 l 0,-0.70735 -1.18605,0.05 q -1.41468,0.05 -2.04343,0.44298 -0.6216,0.38582 -0.6216,1.20749 0,0.64303 0.38582,0.97884 0.39297,0.33581 1.09317,0.33581 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5779"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 573.43251,809.52558 q 0.31437,0 0.60731,-0.0429 0.29294,-0.05 0.46442,-0.10003 l 0,0.9074 q -0.19291,0.0929 -0.57159,0.15005 -0.37154,0.0643 -0.67162,0.0643 -2.27207,0 -2.27207,-2.39353 l 0,-4.65846 -1.12175,0 0,-0.57159 1.12175,-0.493 0.50014,-1.6719 0.68591,0 0,1.8148 2.27207,0 0,0.92169 -2.27207,0 0,4.60844 q 0,0.70735 0.33581,1.08602 0.33581,0.37868 0.92169,0.37868 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5781"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 581.43476,810.36153 0,-5.06571 q 0,-0.95742 -0.43584,-1.42898 -0.43584,-0.47156 -1.36467,-0.47156 -1.23606,0 -1.80765,0.67162 -0.56445,0.67162 -0.56445,2.20062 l 0,4.09401 -1.18605,0 0,-11.11742 1.18605,0 0,3.36523 q 0,0.60732 -0.0572,1.00743 l 0.0715,0 q 0.3501,-0.56444 0.99314,-0.88596 0.65018,-0.32867 1.47899,-0.32867 1.43612,0 2.1506,0.68591 0.72164,0.67876 0.72164,2.1649 l 0,5.10858 -1.18605,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5783"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 587.53649,806.35326 q 0,1.8791 -0.5573,3.50099 -0.55016,1.62188 -1.59331,2.82222 l -1.14318,0 q 0.99314,-1.34323 1.52186,-2.97941 0.52872,-1.64332 0.52872,-3.35809 0,-1.74335 -0.52158,-3.39382 -0.51443,-1.65046 -1.54329,-3.02943 l 1.15747,0 q 1.0503,1.25036 1.60045,2.90797 0.55016,1.65047 0.55016,3.52957 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5785"
+         inkscape:connector-curvature="0" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
@@ -246,19 +1728,41 @@
          style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
          d="m 204.639,587.124 -3.549,0 1.773,3.076 1.776,3.073 1.775,-3.073 1.774,-3.076 -3.549,0" />
     </g>
-    <text
-       xml:space="preserve"
+    <g
+       transform="matrix(0,-1,1,0,0,0)"
        style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="-400.8819"
-       y="516.31042"
-       id="text8536-9"
-       sodipodi:linespacing="521%"
-       transform="matrix(0,-1,1,0,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan8538-3"
-         x="-400.8819"
-         y="516.31042"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">5.08 cm</tspan></text>
+       id="text8536-9">
+      <path
+         d="m -396.49494,509.63711 q 1.51471,0 2.40782,0.85024 0.90025,0.85024 0.90025,2.32923 0,1.7505 -1.07887,2.69362 -1.07888,0.94312 -3.08659,0.94312 -1.74335,0 -2.81508,-0.56444 l 0,-1.90768 q 0.56445,0.30008 1.31466,0.49299 0.75021,0.18577 1.42183,0.18577 2.022,0 2.022,-1.65761 0,-1.57902 -2.09345,-1.57902 -0.37868,0 -0.83595,0.0786 -0.45727,0.0715 -0.74307,0.15719 l -0.87882,-0.47156 0.39297,-5.32293 5.66589,0 0,1.87195 -3.72963,0 -0.19291,2.05058 0.25007,-0.05 q 0.43584,-0.10003 1.07888,-0.10003 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5992"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -391.70073,515.28871 q 0,-0.60017 0.32152,-0.9074 0.32152,-0.30723 0.93598,-0.30723 0.59302,0 0.91454,0.31437 0.32866,0.31438 0.32866,0.90026 0,0.56444 -0.32866,0.89311 -0.32866,0.32152 -0.91454,0.32152 -0.60017,0 -0.92884,-0.31438 -0.32866,-0.32152 -0.32866,-0.90025 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5994"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -380.53329,511.08752 q 0,2.73649 -0.90026,4.05115 -0.89311,1.31465 -2.75792,1.31465 -1.80765,0 -2.72934,-1.35752 -0.91454,-1.35753 -0.91454,-4.00828 0,-2.76507 0.89311,-4.07258 0.8931,-1.31466 2.75077,-1.31466 1.80766,0 2.72934,1.37182 0.92884,1.37182 0.92884,4.01542 z m -5.10859,0 q 0,1.92197 0.32867,2.75792 0.33581,0.82881 1.12174,0.82881 0.77165,0 1.1146,-0.8431 0.34296,-0.84309 0.34296,-2.74363 0,-1.92197 -0.3501,-2.75792 -0.34296,-0.8431 -1.10746,-0.8431 -0.77879,0 -1.1146,0.8431 -0.33581,0.83595 -0.33581,2.75792 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5996"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -375.83196,505.72886 q 1.50042,0 2.41496,0.68591 0.92169,0.67877 0.92169,1.83624 0,0.80022 -0.44298,1.42897 -0.44298,0.6216 -1.42897,1.1146 1.17176,0.62875 1.67904,1.31466 0.51443,0.67876 0.51443,1.49328 0,1.28607 -1.00742,2.07201 -1.00743,0.77879 -2.65075,0.77879 -1.71477,0 -2.69362,-0.72877 -0.97885,-0.72878 -0.97885,-2.06487 0,-0.89311 0.47156,-1.58617 0.47871,-0.69305 1.52901,-1.22177 -0.89311,-0.56445 -1.28608,-1.20748 -0.39297,-0.64304 -0.39297,-1.40754 0,-1.12175 0.92883,-1.8148 0.92884,-0.69306 2.42212,-0.69306 z m -1.62903,7.80221 q 0,0.61446 0.42869,0.95741 0.42869,0.34296 1.17176,0.34296 0.82166,0 1.22892,-0.3501 0.40725,-0.35725 0.40725,-0.93598 0,-0.47871 -0.40725,-0.89311 -0.40012,-0.42155 -1.30752,-0.89311 -1.52185,0.7002 -1.52185,1.77193 z m 1.61474,-6.18746 q -0.56445,0 -0.91455,0.29294 -0.34295,0.28579 -0.34295,0.77164 0,0.4287 0.2715,0.77165 0.27865,0.33581 1.00029,0.69305 0.70019,-0.32866 0.97885,-0.67162 0.27865,-0.34295 0.27865,-0.79308 0,-0.49299 -0.35725,-0.77879 -0.35724,-0.28579 -0.91454,-0.28579 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path5998"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -363.48562,516.45332 q -3.72962,0 -3.72962,-4.09401 0,-2.03629 1.01457,-3.10802 1.01457,-1.07888 2.90797,-1.07888 1.3861,0 2.48641,0.54301 l -0.64304,1.68619 q -0.51443,-0.2072 -0.95741,-0.33581 -0.44298,-0.13575 -0.88596,-0.13575 -1.70049,0 -1.70049,2.41497 0,2.34352 1.70049,2.34352 0.62874,0 1.16461,-0.16433 0.53587,-0.17148 1.07173,-0.52872 l 0,1.86481 q -0.52872,0.33581 -1.07173,0.46441 -0.53587,0.12861 -1.35753,0.12861 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path6000"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m -352.06096,516.31042 -2.17919,0 0,-4.6656 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.83595,0 -1.21463,0.61446 -0.37868,0.61446 -0.37868,2.022 l 0,3.7582 -2.17918,0 0,-7.98797 1.66475,0 0.29294,1.02172 0.12147,0 q 0.32152,-0.55015 0.92883,-0.85738 0.60731,-0.31438 1.39325,-0.31438 1.79336,0 2.42926,1.17176 l 0.19291,0 q 0.32152,-0.5573 0.94312,-0.86453 0.62875,-0.30723 1.41469,-0.30723 1.35752,0 2.05058,0.7002 0.7002,0.69305 0.7002,2.2292 l 0,5.20861 -2.18634,0 0,-4.6656 q 0,-0.86453 -0.29294,-1.29322 -0.28579,-0.43584 -0.9074,-0.43584 -0.80022,0 -1.20033,0.57159 -0.39297,0.57159 -0.39297,1.8148 l 0,4.00827 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="path6002"
+         inkscape:connector-curvature="0" />
+    </g>
     <rect
        y="285.73621"
        x="288.5"

--- a/assets/square-sticker_template.svg
+++ b/assets/square-sticker_template.svg
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8.5in"
+   height="11in"
+   viewBox="0 0 765.00001 990.00003"
+   id="svg7307"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="square-sticker_template.svg">
+  <defs
+     id="defs7309" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.4121212"
+     inkscape:cx="316.35347"
+     inkscape:cy="891.11087"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer4"
+     showgrid="false"
+     units="in"
+     fit-margin-top="1"
+     fit-margin-bottom="1"
+     fit-margin-right="1"
+     fit-margin-left="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="557.18594,704.35932"
+       orientation="0,1"
+       id="guide8412" />
+    <sodipodi:guide
+       position="472.1985,525.26384"
+       orientation="0,1"
+       id="guide8414" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7312">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="Template Text"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <text
+       sodipodi:linespacing="521%"
+       id="text8212"
+       y="101.80281"
+       x="73.142006"
+       style="font-style:normal;font-weight:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.00231552px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="101.80281"
+         x="73.142006"
+         id="tspan8214"
+         sodipodi:role="line">5.08 cm / 2&quot; Square Sticker Template</tspan></text>
+    <text
+       transform="translate(178.67433,582.63783)"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:29.74009705px;line-height:120.00000477%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-85.936043"
+       y="-454.19525"
+       id="text8216"
+       sodipodi:linespacing="120%"><tspan
+         id="tspan8220"
+         sodipodi:role="line"
+         x="-85.936043"
+         y="-454.19525"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.55170345px;line-height:120.00000477%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;writing-mode:lr-tb;text-anchor:start">(This template follows the StickerConstructorSpec at github.com/terinjokes/StickerconstructorSpec)</tspan></text>
+    <rect
+       transform="translate(178.67433,582.63783)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#0093d9;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000003, 4.00000005;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8406"
+       width="21.230001"
+       height="21.23"
+       x="38.762836"
+       y="25.453775" />
+    <rect
+       transform="translate(178.67433,582.63783)"
+       y="-18.546227"
+       x="38.762836"
+       height="21.23"
+       width="21.230001"
+       id="rect8408"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#db3279;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1" />
+    <rect
+       transform="translate(178.67433,582.63783)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8426"
+       width="21.230001"
+       height="21.23"
+       x="38.762836"
+       y="69.453773" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="255.83966"
+       y="580.09589"
+       id="text8536"
+       sodipodi:linespacing="521%"><tspan
+         sodipodi:role="line"
+         id="tspan8538"
+         x="255.83966"
+         y="580.09589"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">Safe area <tspan
+   style="font-weight:normal"
+   id="tspan8540">- Keep all text inside this border</tspan></tspan></text>
+    <text
+       sodipodi:linespacing="521%"
+       id="text8542"
+       y="624.09589"
+       x="255.83966"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="624.09589"
+         x="255.83966"
+         id="tspan8544"
+         sodipodi:role="line">Trim <tspan
+   id="tspan8546"
+   style="font-weight:normal">- Outer edge of sticker</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="255.83966"
+       y="668.09589"
+       id="text8548"
+       sodipodi:linespacing="521%"><tspan
+         sodipodi:role="line"
+         id="tspan8550"
+         x="255.83966"
+         y="668.09589"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
+           style="font-weight:normal"
+           id="tspan8552"><tspan
+   style="font-weight:bold"
+   id="tspan8554">Bleed</tspan> - This area will be trimmed off</tspan></tspan></text>
+    <text
+       sodipodi:linespacing="521%"
+       id="text8556"
+       y="748.41248"
+       x="326.5592"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         y="748.41248"
+         x="326.5592"
+         id="tspan8558"
+         sodipodi:role="line">Make sure you:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:150%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="176.30603"
+       y="788.41248"
+       id="text8562"
+       sodipodi:linespacing="150%"><tspan
+         sodipodi:role="line"
+         id="tspan8564"
+         x="176.30603"
+         y="788.41248"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"><tspan
+   style="font-weight:bold;line-height:150%"
+   id="tspan8572">1.</tspan> Put your artwork in the &quot;Artwork&quot; layer.</tspan><tspan
+         sodipodi:role="line"
+         x="176.30603"
+         y="810.36151"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.63270473px;line-height:150%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start"
+         id="tspan8568"><tspan
+   style="font-weight:bold;line-height:150%"
+   id="tspan8574">2.</tspan> Outline your text. (Select text, then Paths &gt; Object to Path) </tspan></text>
+  </g>
+  <g
+     inkscape:label="Artwork"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(178.67433,582.63783)"
+     style="display:inline">
+    <rect
+       style="opacity:1;fill:#333333;fill-opacity:1;stroke:#f0a028;stroke-width:20.25;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8616"
+       width="171"
+       height="171"
+       x="113.82567"
+       y="-292.90164" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Trim Lines"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <g
+       id="g4595"
+       transform="matrix(1.2367579,0,0,-1.2367579,267.26742,1019.9045)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path470"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 210.14,593.273 -11.002,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path472"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 210.14,449.273 -11.002,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path474"
+         style="fill:none;stroke:#231f20;stroke-width:1.01070714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 204.639,449.273 0,144" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path476"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 204.639,455.424 3.549,0 -1.774,-3.076 -1.775,-3.075 -1.776,3.075 -1.773,3.076 3.549,0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path478"
+         style="fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 204.639,587.124 -3.549,0 1.773,3.076 1.776,3.073 1.775,-3.073 1.774,-3.076 -3.549,0" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-400.8819"
+       y="516.31042"
+       id="text8536-9"
+       sodipodi:linespacing="521%"
+       transform="matrix(0,-1,1,0,0,0)"><tspan
+         sodipodi:role="line"
+         id="tspan8538-3"
+         x="-400.8819"
+         y="516.31042"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.63270473px;line-height:521.00000381%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start">5.08 cm</tspan></text>
+    <rect
+       y="285.73621"
+       x="288.5"
+       height="178.99998"
+       width="179"
+       id="rect8620"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#0093d9;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 4.00000009;stroke-dashoffset:6.5;stroke-opacity:1" />
+    <rect
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       id="rect8624"
+       width="190.25003"
+       height="190.25002"
+       x="282.87497"
+       y="280.11118" />
+    <rect
+       y="291.36118"
+       x="294.125"
+       height="167.75"
+       width="167.75002"
+       id="rect8626"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#db3279;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Preview Without Bleeds"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5;stroke-opacity:1"
+       d="m 258.60352,257.08203 0,236.30664 238.79296,0 0,-236.30664 -238.79296,0 z m 29.89648,28.6543 179,0 0,179 -179,0 0,-179 z"
+       id="rect8631"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
- These templates are made following Sticker Mule's template file format.
- They include bleed, trim, and safe area lines.
- They also assume a 0.125" bleed and a 0.1" wide border in the design.